### PR TITLE
[PAX] equity-trading-markets v1.0.4

### DIFF
--- a/pax/equity-trading-markets/knowledge/construct_relationships.json
+++ b/pax/equity-trading-markets/knowledge/construct_relationships.json
@@ -228,6 +228,18 @@
     "mechanism": "Implied volatility is a forward-looking estimate of realized volatility; the variance risk premium (IV > realized vol) compensates investors for volatility uncertainty"
   },
   {
+    "id": 72,
+    "construct_from": "value_at_risk_etm",
+    "construct_to": "maximum_drawdown_etm",
+    "relationship_type": "correlational",
+    "direction": "positive",
+    "strength": "moderate",
+    "source_id": null,
+    "evidence_weight": null,
+    "n_findings": null,
+    "mechanism": "Both measure tail risk but at different horizons: VaR captures point-in-time loss probability while max drawdown captures cumulative peak-to-trough loss over a full cycle"
+  },
+  {
     "id": 70,
     "construct_from": "earnings_surprise_etm",
     "construct_to": "price_momentum_etm",

--- a/pax/equity-trading-markets/pax.yaml
+++ b/pax/equity-trading-markets/pax.yaml
@@ -64,5 +64,5 @@ provides:
   - shleifer_vishny_1997
   - markowitz_1952
   - baker_wurgler_2006
-schema_version: '1.0'
-version: 1.0.3
+schema_version: '2.0'
+version: 1.0.4


### PR DESCRIPTION
## Pack: equity-trading-markets
- **Type:** field
- **Version:** 1.0.4
- **Quality Score:** 42.41
- **Constructs:** 25
- **Description:** Equity market theory, quantitative trading strategies, technical and fundamental analysis, risk management, behavioral finance, and options basics — with live data engines for real-time stock analysis. Covers EMH and its violations, momentum/value/mean-reversion anomalies, technical indicator theory, portfolio optimization, factor models, and options pricing.

## Changelog
v1.0.4: Migrated to PAX schema v2.0

## Published by
mcp_agent

---
🤖 Auto-generated by praxis_publish_pax