### PR TITLE
fix: accept schema_version 3.0 in PR validation

### DIFF
--- a/.github/workflows/validate-pack.yml
+++ b/.github/workflows/validate-pack.yml
@@ -29,7 +29,7 @@ jobs:
 
           REQUIRED_MANIFEST = ['name', 'version', 'description', 'pax_type', 'schema_version']
           VALID_TYPES = ['paper', 'topic', 'field', 'engine', 'enterprise']
-          VALID_SCHEMA_VERSIONS = ['1.0', '2.0']
+          VALID_SCHEMA_VERSIONS = ['1.0', '2.0', '3.0']
           errors = []
           warnings = []
 


### PR DESCRIPTION
## Summary
- Adds `"3.0"` to `VALID_SCHEMA_VERSIONS` in `.github/workflows/validate-pack.yml`
- Unblocks all praxis-v3 PAX submissions (P0 blocker per issue #59)

Closes #59

## Test plan
- [ ] CI passes on this PR (no pax/ changes → validation skips, but file syntax still loads)
- [ ] Verify a v3 manifest submission validates after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)