### PR TITLE
chore: remove dead website-dispatch step from publish-artifacts

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -45,7 +45,9 @@ jobs:
         run: |
           # Delete existing 'latest' release if it exists
           gh release delete latest --yes 2>/dev/null || true
-          # Create new release
+          # Create new release. The homelab (CT 105 pax-autodeploy.timer) polls
+          # this release's `updated_at` timestamp every 5 min and rebuilds
+          # pax-market.com when it changes — no GitHub-side dispatch needed.
           gh release create latest \
             --title "Latest Registry Artifacts" \
             --notes "Auto-generated registry artifacts from commit ${{ github.sha }}" \
@@ -53,19 +55,4 @@ jobs:
             dist/constructs.json \
             dist/full-catalog.json \
             dist/pax-archives.tar
-
-      - name: Trigger website deploy
-        env:
-          PAX_WEBSITE_DISPATCH_TOKEN: ${{ secrets.PAX_WEBSITE_DISPATCH_TOKEN }}
-        run: |
-          if [ -z "$PAX_WEBSITE_DISPATCH_TOKEN" ]; then
-            echo "WARNING: PAX_WEBSITE_DISPATCH_TOKEN not set — skipping website dispatch"
-            exit 0
-          fi
-          curl -fsS -X POST \
-            -H "Authorization: token $PAX_WEBSITE_DISPATCH_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/JELambert/pax-website/dispatches \
-            -d '{"event_type":"registry-updated"}'
-          echo "Website deploy triggered."
 


### PR DESCRIPTION
## Summary
- Removes the "Trigger website deploy" step that depended on `PAX_WEBSITE_DISPATCH_TOKEN`.
- Adds a comment to the release-creation step explaining how the homelab consumes the artifact.

## Why
Pax-website is rebuilt by CT 105 (`/opt/pax-website/scripts/ct105-autodeploy.sh`, run every 5 min by `pax-autodeploy.timer`) which polls `api.github.com/.../releases/latest` and triggers a Hugo build + rsync to CT 110 when `updated_at` changes. The cross-repo `repository_dispatch` token-based path was abandoned in favor of the homelab pull model. The dead step was silently `exit 0`-ing on every run for ~9 days; removing it eliminates the false-green and the unused secret dependency.

Closes #58.

## Test plan
- [ ] Workflow YAML still parses (gh actions UI shows no syntax errors)
- [ ] Next merge to main creates a fresh GitHub Release as before
- [ ] CT 105 picks up the new `updated_at` within 5 min and rebuilds pax-market.com (already verified working today after manual `gh workflow run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)