### PR TITLE
feat: pass through praxis-v3 fields in generate-registry

### DIFF
--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -136,6 +136,9 @@ def process_pack(pack_dir: Path) -> dict | None:
     sources = load_json(knowledge_dir / "sources.json")
     domain_data = load_json(knowledge_dir / "domain.json")
     construct_relationships = load_json(knowledge_dir / "construct_relationships.json")
+    # v3: optional canonical-construct backbone files
+    canonical_constructs = load_json(knowledge_dir / "canonical_constructs.json")
+    construct_relations = load_json(knowledge_dir / "construct_relations.json")
 
     # Construct details
     constructs_detail = []
@@ -148,6 +151,10 @@ def process_pack(pack_dir: Path) -> dict | None:
             "definition": c.get("definition", ""),
             "aliases": aliases,
             "construct_type": c.get("construct_type", ""),
+            # v3: canonical-construct backbone
+            "canonical_id": c.get("canonical_id"),
+            "operationalization_id": c.get("operationalization_id"),
+            "coding_rule": c.get("coding_rule"),
         })
 
     # Finding details
@@ -174,6 +181,10 @@ def process_pack(pack_dir: Path) -> dict | None:
             "ci_upper": f.get("ci_upper"),
             "model_specification": f.get("model_specification"),
             "covariates_controlled": f.get("covariates_controlled"),
+            # v3: scope/unit metadata for cross-PAX comparison & meta-analysis pooling
+            "unit_of_analysis": f.get("unit_of_analysis"),
+            "scope_conditions": f.get("scope_conditions"),
+            "sample_n": f.get("sample_n"),
         })
 
     # Proposition details
@@ -355,6 +366,9 @@ def process_pack(pack_dir: Path) -> dict | None:
         "sources_detail": sources_detail,
         "playbooks_detail": playbooks_detail,
         "relationships_detail": relationships_detail,
+        # v3: pass-through of canonical-construct backbone (empty list if pack lacks them)
+        "canonical_constructs": canonical_constructs,
+        "construct_relations": construct_relations,
         "quality": quality,
         "pax_schema_version": manifest.get("schema_version", "1.0"),
         "download_url": f"{MARKETPLACE_BASE_URL}/pax/{name}.pax.tar.gz",


### PR DESCRIPTION
## Summary
- **#60** — Adds `unit_of_analysis`, `scope_conditions`, `sample_n` to each entry in `findings_detail`.
- **#61** — Adds `canonical_id`, `operationalization_id`, `coding_rule` to each entry in `constructs_detail`. Reads `knowledge/canonical_constructs.json` and `knowledge/construct_relations.json` when present and surfaces them as new pack-dict keys `canonical_constructs` and `construct_relations`.

## Backwards compatibility
PAX without these fields/files: fields resolve to `null`, files resolve to `[]`. No regression — verified by regenerating the current 12-pack registry locally; all packs build, output sizes within normal range.

## Verification
```
$ python3 scripts/generate-registry.py
Registry: 12 packs (13.2 KB)
Constructs: 318 (200.5 KB)
Full catalog: 1148.5 KB
Done! 12 packs processed.
```
Inspected `dist/full-catalog.json` — new keys present on a sample pack:
- `constructs_detail[0]` keys now include `canonical_id`, `operationalization_id`, `coding_rule`
- `findings_detail[0]` keys now include `unit_of_analysis`, `scope_conditions`, `sample_n`
- pack-level keys now include `canonical_constructs`, `construct_relations`

## Downstream
The website-side render of these fields (Hugo templates) is a separate concern tracked on pax-website. This PR only ensures the data is present in `full-catalog.json` for the homelab CT 105 deploy pipeline to consume.

Closes #60, #61.

## Test plan
- [ ] CI green (no `pax/**` changes → validation skip path)
- [ ] After merge, `Publish Registry Artifacts` runs and the new release's `full-catalog.json` contains the new fields
- [ ] CT 105 pulls within 5 min and rebuilds successfully (homelab generate-content.py tolerates extra fields it doesn't yet use)

🤖 Generated with [Claude Code](https://claude.com/claude-code)