### PR TITLE
fix: respect manifest published_by; attribute smith-lambert pack to authors

### DIFF
--- a/pax/smith-lambert-2026-beigesage/pax.yaml
+++ b/pax/smith-lambert-2026-beigesage/pax.yaml
@@ -10,6 +10,7 @@ description: >
 schema_version: "3.0"
 pax_type: paper
 author: "Smith, Charlie; Lambert, Joshua"
+published_by: "Smith, Charlie; Lambert, Joshua"
 created: "2026-04-28"
 license: CC-BY-4.0
 tags:

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -374,7 +374,7 @@ def process_pack(pack_dir: Path) -> dict | None:
         "download_url": f"{MARKETPLACE_BASE_URL}/pax/{name}.pax.tar.gz",
         "download_sha256": sha256,
         "download_size": archive_size,
-        "published_by": "Praxis Agent",
+        "published_by": manifest.get("published_by") or "Praxis Agent",
     }
 
 


### PR DESCRIPTION
## Summary
- `generate-registry.py:377` — read `published_by` from the manifest if set; fall back to `"Praxis Agent"` (preserves current behavior for the 11 Praxis-Agent-generated packs that don't declare the field).
- `pax/smith-lambert-2026-beigesage/pax.yaml` — set `published_by: "Smith, Charlie; Lambert, Joshua"` so this community-submitted pack stops being mis-attributed to Praxis Agent on the live site.

## Why
Every pack on pax-market.com currently shows `published by: Praxis Agent` regardless of origin, because the value is hardcoded in the registry generator. Community-submitted packs (smith-lambert-2026-beigesage being the first one to surface) get incorrectly labeled.

## Verification
After regenerating locally:
```
smith-lambert-2026-beigesage   published_by='Smith, Charlie; Lambert, Joshua'
all 12 others                  published_by='Praxis Agent'   ← unchanged
```

## Follow-up (separate, on praxis)
The PAX creation guide (`docs/PAX_CREATION_GUIDE.md`) doesn't document the `published_by` field. Issue filed there to add it as an optional/recommended field for community submissions, so future PAX uploads naturally include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)