### PR TITLE
feat: auto-stamp published_by from PR submitter

### DIFF
--- a/.github/workflows/stamp-published-by.yml
+++ b/.github/workflows/stamp-published-by.yml
@@ -1,0 +1,68 @@
+name: Stamp published_by
+
+on:
+  pull_request_target:
+    branches: [main]
+    paths: ['pax/**/pax.yaml']
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  stamp:
+    runs-on: ubuntu-latest
+    # Only run on PRs from the same repo — pull_request_target on forks would
+    # let a fork edit its own manifest, but pushing back requires same-repo write.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stamp missing published_by on changed pax.yaml files
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Find pax.yaml files touched in this PR
+          mapfile -t CHANGED < <(git diff --name-only "$BASE_SHA..$HEAD_SHA" -- 'pax/**/pax.yaml')
+          if [ ${#CHANGED[@]} -eq 0 ]; then
+            echo "No pax.yaml changes in this PR."
+            exit 0
+          fi
+          MODIFIED=0
+          for f in "${CHANGED[@]}"; do
+            [ -f "$f" ] || continue
+            if grep -qE '^[[:space:]]*published_by:' "$f"; then
+              echo "  $f already has published_by — skipping"
+              continue
+            fi
+            # Insert after the `author:` line if present, else after the first line
+            if grep -qE '^[[:space:]]*author:' "$f"; then
+              awk -v who="$PR_AUTHOR" '
+                {print}
+                /^[[:space:]]*author:/ && !done { print "published_by: \"" who "\""; done=1 }
+              ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+            else
+              awk -v who="$PR_AUTHOR" '
+                NR==1 { print; print "published_by: \"" who "\""; next }
+                {print}
+              ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+            fi
+            echo "  $f stamped published_by: $PR_AUTHOR"
+            MODIFIED=$((MODIFIED+1))
+          done
+          if [ "$MODIFIED" -eq 0 ]; then
+            echo "Nothing to stamp."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add pax/
+          git commit -m "chore: auto-stamp published_by: $PR_AUTHOR"
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"

--- a/pax/smith-lambert-2026-beigesage/pax.yaml
+++ b/pax/smith-lambert-2026-beigesage/pax.yaml
@@ -10,7 +10,7 @@ description: >
 schema_version: "3.0"
 pax_type: paper
 author: "Smith, Charlie; Lambert, Joshua"
-published_by: "Smith, Charlie; Lambert, Joshua"
+published_by: "JELambert"
 created: "2026-04-28"
 license: CC-BY-4.0
 tags:


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/stamp-published-by.yml` — on every PR that touches `pax/**/pax.yaml`, scan the changed manifests, and if `published_by` is missing, insert `published_by: "<PR-author-login>"` and commit it back to the PR branch.
- Update `pax/smith-lambert-2026-beigesage/pax.yaml`: `published_by` flipped from `"Smith, Charlie; Lambert, Joshua"` (set in #68) to `"JELambert"` to match the new submitter-login convention.

## Why
PR #68 made `generate-registry.py` respect the manifest's `published_by`. This PR makes the **default** be the GitHub username of whoever submitted the pack — so community submitters don't need to touch the field manually, and the live marketplace correctly attributes packs to the people who shipped them.

## How it works
1. Submitter opens a PR adding/editing a pack.
2. `stamp-published-by.yml` fires (alongside validate-pack and auto-merge).
3. If the manifest already declares `published_by`, the workflow no-ops.
4. Otherwise it inserts `published_by: "<github.event.pull_request.user.login>"` right after the `author:` line, commits as `github-actions[bot]`, and pushes back to the PR branch.
5. Auto-merge / manual merge proceeds. Registry generation reads the now-stamped field.

## Limitations
- **Same-repo PRs only.** The same-repo `if` guard exists because `pull_request_target` cannot push back to a fork branch without elevated tokens. Forks will hit the existing fallback (`"Praxis Agent"`) until we wire up a fork-friendly mechanism. Worth a follow-up issue if/when fork submissions become common.
- **`pull_request_target` carries write privileges** — the workflow only runs the `git diff` and a deterministic `awk` over the manifests; it never executes user-supplied code. Standard hardening for this trigger.

## Test plan
- [ ] After merge, open a synthetic PR adding a tiny pack with no `published_by` → verify the workflow inserts `published_by: <your-login>` and pushes to the PR branch
- [ ] Open a PR with `published_by` already set → verify the workflow leaves it alone
- [ ] After merge, smith-lambert page on pax-market.com shows `published by: JELambert`

🤖 Generated with [Claude Code](https://claude.com/claude-code)