### PR TITLE
feat: pax-market is now canonical home of PAX guides (Phase 1)

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -3,7 +3,7 @@ name: Publish Registry Artifacts
 on:
   push:
     branches: [main]
-    paths: ['pax/**', 'scripts/generate-registry.py']
+    paths: ['pax/**', 'scripts/generate-registry.py', 'docs/**']
   workflow_dispatch:
 
 permissions:
@@ -35,6 +35,19 @@ jobs:
           echo "Found $PACK_COUNT pack archives"
           test "$PACK_COUNT" -gt 0 || (echo "No pack archives found" && exit 1)
 
+      - name: Verify guide markers
+        # Loud failure: if either marker is missing, praxis pax_schema.py
+        # parsing breaks at import time. Don't ship a release that would
+        # poison the downstream consumer.
+        run: |
+          set -euo pipefail
+          test -s docs/PAX_CREATION_GUIDE.md
+          test -s docs/PAX_USAGE_GUIDE.md
+          grep -q '<!-- PAX_SCHEMA_START' docs/PAX_CREATION_GUIDE.md
+          grep -q '<!-- PAX_SCHEMA_END'   docs/PAX_CREATION_GUIDE.md
+          grep -q '<!-- PAX_FIELDS_START' docs/PAX_CREATION_GUIDE.md
+          grep -q '<!-- PAX_FIELDS_END'   docs/PAX_CREATION_GUIDE.md
+
       - name: Bundle pack archives
         run: |
           cd dist && tar -cf pax-archives.tar pax/
@@ -54,5 +67,7 @@ jobs:
             dist/registry.json \
             dist/constructs.json \
             dist/full-catalog.json \
-            dist/pax-archives.tar
+            dist/pax-archives.tar \
+            docs/PAX_CREATION_GUIDE.md \
+            docs/PAX_USAGE_GUIDE.md
 

--- a/docs/PAX_CREATION_GUIDE.md
+++ b/docs/PAX_CREATION_GUIDE.md
@@ -1,0 +1,1105 @@
+# PAX v3 Specification & Creation Guide
+
+> **Schema version:** 3.0 — Last updated: 2026-04-28
+>
+> This document is the canonical specification for PAX v3. All future PAX schema changes are documented here. For v1→v2 migration context, see `docs/adr/ADR-007-pax-v2-schema-evolution.md`. PAX v3 builds on v2 by adding the canonical-construct backbone, structured statistics, and minting governance (Sprints 7–9).
+
+## What Is This Document?
+
+A self-contained guide for creating Praxis PAX (Portable Analytical eXpertise) packages. You can:
+
+1. **Feed it to any LLM** (ChatGPT, Claude, Gemini, Llama) with source material → get a valid PAX out
+2. **Use it as a spec** to build PAX tooling in any language
+3. **Validate PAX packages** against the schema and checklist below
+
+**No Praxis runtime required.** This guide produces static files (YAML + JSON). The output can be validated offline, then imported into any Praxis instance or published to the [PAX Marketplace](https://pax-market.com).
+
+---
+
+## What's New in v3
+
+PAX v3 extends v2 with a canonical-construct backbone, structured quantitative metadata, and explicit minting governance. The headline changes:
+
+- **Canonical / operationalization split.** Constructs now distinguish *canonical* concepts (the universal idea — e.g., "civil war onset") from *operationalizations* (a specific measurement choice tied to a source — e.g., "ACD onset, ≥1000 battle deaths"). This lets multiple papers map to the same canonical construct without flattening their measurement differences.
+- **`canonical_constructs.json`.** A new top-level PAX file lists canonical constructs with `canonical_status` (`provisional`, `canonical`, `deprecated`), `construct_kind`, and a `provenance_json` minting record. Operationalizations in `constructs.yaml` carry an `operationalization_status` (`active`, `deprecated`) and an FK to their canonical parent.
+- **`construct_relations.json`.** Backbone relations between canonical constructs use a controlled `relation_type` vocabulary (`subsumes`, `refines`, `disjoint_from`, `equivalent_to`). This is separate from the v2 `construct_relationships` (causal/correlational links between operationalizations).
+- **Structured statistics on findings.** Findings can now carry `effect_size_value`, `effect_size_se`, `p_value`, `sample_size`, `r_squared`, `ci_lower`/`ci_upper`, `effect_size_type`, `model_specification`, and `covariates_controlled` as first-class fields. Populate these whenever the source reports them — they unlock meta-analysis and quantitative KB comparison.
+- **`unit_of_analysis` on findings.** Findings declare their unit (`country-year`, `dyad-year`, `individual`, `patient`, etc.) so engines can correctly pool, dedupe, or refuse to mix incompatible units.
+- **Governance log + minting controls.** Promotion of a construct from `provisional` to `canonical` is gated and logged. Each mint records who/what proposed it and why, leaving an auditable trail in `provenance_json` and the governance section of the PAX.
+
+Existing v2 PAX packages remain valid inputs. The canonical backbone is additive: omit the new files and the package behaves like a v2 PAX, with all operationalizations treated as their own canonical roots.
+
+---
+
+## What Is a PAX?
+
+A PAX is a portable knowledge package that captures everything needed to understand and analyze a domain — academic, business, or applied:
+
+- **What concepts exist** (constructs with formal/operational definitions)
+- **What we know** (findings with structured statistics)
+- **Where we learned it** (sources with methodology metadata)
+- **How concepts relate** (construct relationships)
+- **What theories say** (propositions with scope conditions)
+- **How to analyze it** (playbooks — reproducible analysis workflows)
+
+### PAX Types
+
+| Type | When to Use | Typical Size | Example |
+|------|-------------|--------------|---------|
+| `paper` | Single research paper | 5-15 constructs, 4-10 findings, 1 source | Fearon & Laitin (2003) on civil war onset |
+| `topic` | Research topic spanning multiple papers | 6-30 constructs, 10-50 findings, 3-15 sources | Democratic peace theory |
+| `field` | Entire research field or comprehensive body of work | 30-100+ constructs, 50-300+ findings, 20-150 sources | Bartel computational materials science (142 papers) |
+| `enterprise` | Business/industry domain | 5-20 constructs, variable findings, internal + external sources | SaaS customer churn prediction |
+| `engine` | Analytical method package (no domain knowledge) | 0-5 constructs, bundled Python engines | Bayesian regression methods |
+
+**Paper PAX** — Start here. Read one paper, extract its contribution. Good for building up a topic incrementally.
+
+**Topic PAX** — Synthesize multiple papers on a theme. Requires cross-paper construct alignment and often has propositions that span sources.
+
+**Field PAX** — Comprehensive coverage of a researcher's body of work or an entire subdiscipline. Usually built by extending a topic PAX repeatedly. May have sub-domains with `parent_domain_id`.
+
+**Enterprise PAX** — Business analytics domain. Uses the same schema but constructs are often KPIs, findings come from internal analyses, and playbooks encode business-relevant workflows.
+
+---
+
+## Output Structure
+
+Produce the following files:
+
+```
+my-pax-name/
+├── pax.yaml                           # Manifest (required)
+├── knowledge/
+│   ├── domain.json                    # Domain definition (required)
+│   ├── constructs.json                # Construct definitions / operationalizations (required)
+│   ├── sources.json                   # Source/paper metadata (required)
+│   ├── findings.json                  # Empirical findings (required)
+│   ├── propositions.json              # Theoretical claims (recommended)
+│   ├── construct_relationships.json   # Causal/correlational links between operationalizations (recommended)
+│   ├── canonical_constructs.json      # v3 — Canonical concepts (recommended for v3 PAX)
+│   └── construct_relations.json       # v3 — Backbone relations between canonicals (recommended for v3 PAX)
+└── playbooks/
+    └── quick_start.yaml               # Analysis workflow (recommended)
+```
+
+> **v3 note.** `canonical_constructs.json` and `construct_relations.json` are the v3 backbone files. Omit them and the package behaves like v2 (each operationalization is treated as its own canonical root). See "Concept vs. Operationalization" later in this guide.
+
+---
+
+## Step-by-Step Extraction Protocol
+
+### Step 1: Classify Your Input
+
+Read the source material and determine:
+- **PAX type**: paper (single paper), topic (multiple papers on a theme), field (comprehensive coverage), enterprise (business domain)
+- **Method type(s)**: regression, experimental/RCT, qualitative, theoretical, meta-analysis, descriptive, ML/predictive
+- **Unit of analysis**: country-year, individual, firm, dyad, patient, product, customer, etc.
+- **Domain scope**: What research field or business area does this cover?
+
+**For a single paper:** Extract exactly what the paper claims.
+**For a topic:** Identify the shared constructs across papers, note where findings agree or conflict.
+**For a field:** Organize into sub-domains with a parent domain, expect 50+ constructs.
+**For enterprise:** Map business metrics to constructs, internal analyses to findings.
+
+### Step 2: Create the Manifest (`pax.yaml`)
+
+```yaml
+name: dukalskis-et-al-2024-transnational-repression    # kebab-case, unique
+version: "1.0.0"
+description: >
+  First large-N quantitative study of domestic drivers of transnational
+  repression. Tests the hypothesis that authoritarian crackdowns at home
+  increase subsequent likelihood of repressing citizens abroad.
+schema_version: "3.0"
+pax_type: paper          # paper | topic | field | enterprise | engine
+author: "Dukalskis, Alexander; Furstenberg, Saipira; Hellmeier, Sebastian; Scales, Redmond"
+created: "2024-01-15"
+license: CC-BY-4.0
+tags: [transnational-repression, authoritarianism, human-rights, V-Dem]
+provides:
+  constructs:
+    - transnational_repression_binary
+    - domestic_repression_cli
+    - diplomatic_capacity_abroad
+    # ... list all construct IDs
+  sources:
+    - dukalskis_et_al_2024
+  findings:
+    - dukalskis_2024_finding_0
+    - dukalskis_2024_finding_1
+    # ... list all finding IDs
+  propositions:
+    - domestic_crackdown_causes_tr
+    - diplomatic_capacity_amplifies_tr
+  playbooks:
+    - quick_start
+  engines: []             # list registered engine IDs the PAX uses
+```
+
+**Required fields:** name, version, description, schema_version, pax_type
+**pax_type values:**
+- `paper` — single paper
+- `topic` — research topic (multiple papers)
+- `field` — entire research field
+- `enterprise` — business/industry domain
+- `engine` — analytical method package
+
+**Optional manifest fields:**
+- `published_by` *(string)* — Display name shown as the publisher on [pax-market.com](https://pax-market.com). If unset, the marketplace registry workflow auto-stamps the GitHub username of the PR submitter at submission time. Set this explicitly only if you want a custom value (an organization name, a multi-author credit, or "Praxis Agent" for automated PAX generation). **Do not set it speculatively** — leaving it unset gives the right default for community submissions.
+
+### Step 3: Define the Domain (`knowledge/domain.json`)
+
+```json
+{
+  "id": "transnational_repression",
+  "display_name": "Transnational Repression",
+  "description": "State repression of citizens beyond national borders — threats, surveillance, abductions, assassinations targeting diaspora and exiles.",
+  "temporal_scope": "1991-2019",
+  "population": "Authoritarian regimes (88 states, country-year panel)",
+  "level_of_analysis": "macro",
+  "research_questions": [
+    "Does domestic repression predict transnational repression?",
+    "What role does diplomatic capacity play in enabling TR?"
+  ]
+}
+```
+
+**Required:** id (snake_case), display_name, description
+**level_of_analysis:** micro, meso, macro, cross-level, dyadic
+
+### Step 4: Extract Constructs (`knowledge/constructs.json`)
+
+Constructs are the atomic building blocks — every variable, concept, or measurable thing.
+
+```json
+[
+  {
+    "id": "transnational_repression_binary",
+    "display_name": "Transnational Repression (Binary)",
+    "construct_type": "outcome",
+    "definition": "Binary indicator equal to 1 if an authoritarian state carried out one or more transnational repression events against its own citizens abroad in a given country-year. Source: AAAD database (Dukalskis 2021).",
+    "domain_ids": ["transnational_repression"],
+    "source_id": "dukalskis_et_al_2024",
+    "formal_definition": "TR ∈ {0, 1} where TR=1 iff count of AAAD events > 0 in country-year t.",
+    "operational_definition": "Coded from the Authoritarian Actions Abroad Database (AAAD), which records threats, arrests, extraditions, abductions, and assassinations.",
+    "measurement_level": "nominal",
+    "aliases": [
+      {"alias": "TR", "alias_type": "abbreviation"},
+      {"alias": "extraterritorial repression", "alias_type": "synonym"}
+    ],
+    "measures": [
+      "AAAD binary indicator (Dukalskis 2021)",
+      "Freedom House transnational repression report"
+    ]
+  },
+  {
+    "id": "domestic_repression_cli",
+    "display_name": "Domestic Repression (V-Dem CLI)",
+    "construct_type": "quantifiable",
+    "definition": "Inverted V-Dem Civil Liberties Index measuring intensity of domestic state repression. Higher values = more repression. Aggregates physical violence, political civil liberties, and private civil liberties sub-indices. Lagged one year.",
+    "domain_ids": ["transnational_repression"],
+    "source_id": "dukalskis_et_al_2024",
+    "formal_definition": "CLI_inv = 1 - CLI, where CLI is the V-Dem Civil Liberties Index (v2x_civlib).",
+    "operational_definition": "V-Dem v12 Civil Liberties Index, inverted so higher = more repressive, lagged t-1.",
+    "measurement_level": "interval",
+    "aliases": [
+      {"alias": "V-Dem civil liberties", "alias_type": "synonym"},
+      {"alias": "CLI", "alias_type": "abbreviation"}
+    ],
+    "measures": ["V-Dem v12 v2x_civlib (inverted, lagged)"]
+  }
+]
+```
+
+**Required:** id (snake_case), display_name, construct_type, definition
+**construct_type values:** quantifiable, concept, process, composite, outcome
+**Recommended (added in v2):** formal_definition, operational_definition, measurement_level, aliases, measures
+
+**Rules:**
+- One construct per distinct variable or concept
+- Definition must be at least one full sentence
+- Include how it's measured (operationalization)
+- Include aliases (abbreviations, synonyms) for dedup matching
+- `measurement_level`: nominal, ordinal, interval, ratio
+
+### Step 5: Register Sources (`knowledge/sources.json`)
+
+```json
+[
+  {
+    "id": "dukalskis_et_al_2024",
+    "source_type": "academic_paper",
+    "title": "The Long Arm and the Iron Fist: Authoritarian Crackdowns and Transnational Repression",
+    "authors": "Dukalskis, Alexander; Furstenberg, Saipira; Hellmeier, Sebastian; Scales, Redmond",
+    "year": 2024,
+    "doi": "10.1177/00220027231188896",
+    "abstract": "Investigates domestic determinants of transnational repression...",
+    "methodology_summary": "Country-year panel regression (logistic) with country and year fixed effects, bias-reducing score adjustments (bife package). Robustness: negative binomial, rare events logit, lagged DV.",
+    "sample_size": 857,
+    "population_description": "88 authoritarian regimes, 1991-2019 (country-year panel)",
+    "study_design": "observational_longitudinal",
+    "key_limitations": "AAAD captures reported events only (detection bias); excludes digital surveillance; country-year aggregation may miss within-year dynamics",
+    "replication_status": "not_attempted",
+    "data_availability": "public",
+    "journal": "Journal of Conflict Resolution",
+    "url": "https://doi.org/10.1177/00220027231188896"
+  }
+]
+```
+
+**Required:** id (snake_case), source_type, title
+**source_type values:** academic_paper, journal_article, book, book_chapter, working_paper, report, dataset, manual
+**Recommended (added in v2):** methodology_summary, sample_size, study_design, key_limitations, journal
+
+**study_design values:** rct, quasi_experimental, observational_longitudinal, observational_cross_sectional, case_study, meta_analysis, review, theoretical
+
+### Step 6: Extract Findings (`knowledge/findings.json`)
+
+This is the most critical step. Each finding is ONE specific empirical claim.
+
+```json
+[
+  {
+    "source_id": "dukalskis_et_al_2024",
+    "domain_id": "transnational_repression",
+    "finding_text": "Domestic repression is positively and significantly associated with subsequent transnational repression: β=1.09, SE=0.20, p<0.001 (logistic regression with country/year FE, N=857). First large-N quantitative confirmation that domestic crackdowns predict TR.",
+    "construct_ids": ["transnational_repression_binary", "domestic_repression_cli"],
+    "direction": "positive",
+    "effect_size": "β=1.09 (SE=0.20), p<0.001 — bivariate logistic with country/year FE",
+    "method_used": "logistic regression with country and year fixed effects, bias-reducing score adjustments (bife), N=857",
+    "confidence": "strong",
+    "finding_type": "empirical",
+    "evidence_type": "quantitative",
+    "state": "provisional",
+
+    "effect_size_value": 1.09,
+    "effect_size_se": 0.20,
+    "p_value": 0.001,
+    "sample_size": 857,
+    "r_squared": null,
+    "ci_lower": null,
+    "ci_upper": null,
+    "effect_size_type": "beta",
+    "model_specification": "logistic regression with country and year fixed effects, bias-reducing score adjustments (bife)",
+    "covariates_controlled": [],
+
+    "unit_of_analysis": "country-year",
+    "scope_conditions": "Authoritarian regimes (Polity ≤ 5), 1991–2019, AAAD-coverage countries"
+  },
+  {
+    "source_id": "dukalskis_et_al_2024",
+    "domain_id": "transnational_repression",
+    "finding_text": "Domestic repression remains significant after full controls: β=0.83, SE=0.26, p<0.01 (Model 2, N=731). Controls: polity score, elections, leader tenure, military dimension, party dimension, population, GDP per capita, state capacity.",
+    "construct_ids": ["transnational_repression_binary", "domestic_repression_cli"],
+    "direction": "positive",
+    "effect_size": "β=0.83 (SE=0.26), p<0.01 — full controls model",
+    "method_used": "logistic regression with country/year FE, full controls, N=731",
+    "confidence": "strong",
+    "finding_type": "empirical",
+    "evidence_type": "quantitative",
+    "state": "provisional",
+
+    "effect_size_value": 0.83,
+    "effect_size_se": 0.26,
+    "p_value": 0.01,
+    "sample_size": 731,
+    "effect_size_type": "beta",
+    "model_specification": "logistic regression with country/year FE, bias-reducing score adjustments",
+    "covariates_controlled": ["polity_score", "elections", "leader_tenure", "military_dimension", "party_dimension", "population", "gdp_per_capita", "state_capacity"],
+    "unit_of_analysis": "country-year",
+    "scope_conditions": "Authoritarian regimes (Polity ≤ 5), 1991–2019, full-controls model (Model 2)"
+  }
+]
+```
+
+**Required:** source_id, domain_id, finding_text (≥20 chars), construct_ids (≥1), direction
+**direction values:** positive, negative, null, conditional, unknown
+**confidence values:** strong, moderate, weak, unknown
+**finding_type values:** empirical, theoretical, normative, mechanism, methodological
+**evidence_type values:** quantitative, qualitative, mixed, theoretical
+
+**Structured Statistics (added in v2 — ALWAYS populate when available):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| effect_size_value | number | The numeric coefficient (β, OR, r, d, HR, etc.) |
+| effect_size_se | number | Standard error of the estimate |
+| p_value | number | p-value (use 0.001 for p<0.001) |
+| sample_size | integer | N for this specific model |
+| r_squared | number | Model R² if reported |
+| ci_lower | number | Lower bound of confidence interval |
+| ci_upper | number | Upper bound of confidence interval |
+| effect_size_type | enum | What kind of effect — see [Choosing effect_size_type](#choosing-effect_size_type) |
+| model_specification | string | Full model spec (e.g. "OLS with clustered SE by country") |
+| covariates_controlled | array | List of control variable names |
+| unit_of_analysis | enum | What each row in the underlying data represents — see [Choosing unit_of_analysis](#choosing-unit_of_analysis) |
+| scope_conditions | string | Where/when the finding holds — sample restrictions, time window, population filter |
+
+**Set to null if not available. Never guess.**
+
+> **Important:** `unit_of_analysis` is required for engine compatibility — defaulting to `other` defeats the field's purpose. See [Choosing unit_of_analysis](#choosing-unit_of_analysis) below before authoring findings.
+
+**Finding Extraction Rules:**
+1. 4-10 findings per paper (more for large papers)
+2. One specific claim per finding — not a paper summary
+3. Include NULL findings (direction="null") — they are as important as significant ones
+4. Each finding references exactly the constructs involved (usually 2)
+5. `effect_size` (text) is for narrative summary; structured fields are for computation
+6. Always specify the method, sample size, and controls
+
+### Step 7: Define Propositions (`knowledge/propositions.json`)
+
+Propositions are theoretical claims — the "why" behind findings.
+
+```json
+[
+  {
+    "id": "domestic_crackdown_causes_tr",
+    "proposition_text": "An increase in domestic repression leads to subsequent transnational repression, because crackdowns drive dissidents abroad who become targets, and activate state surveillance of international links.",
+    "construct_from": "domestic_repression_cli",
+    "construct_to": "transnational_repression_binary",
+    "direction": "positive",
+    "domain_id": "transnational_repression",
+    "source_id": "dukalskis_et_al_2024",
+    "theoretical_basis": "Authoritarian survival theory; regime-diaspora threat perception",
+    "scope_conditions": "Authoritarian regimes only; lagged effect (t-1 → t); amplified by diplomatic capacity"
+  }
+]
+```
+
+**Required:** id, proposition_text, construct_from, construct_to
+**Recommended:** direction, theoretical_basis, scope_conditions
+
+### Step 8: Define Construct Relationships (`knowledge/construct_relationships.json`)
+
+Explicit causal/correlational links between constructs.
+
+```json
+[
+  {
+    "construct_from": "domestic_repression_cli",
+    "construct_to": "transnational_repression_binary",
+    "relationship_type": "causal",
+    "direction": "positive",
+    "strength": "strong",
+    "mechanism": "Domestic crackdowns drive dissidents abroad and activate state surveillance of international links, increasing TR likelihood.",
+    "source_id": "dukalskis_et_al_2024"
+  },
+  {
+    "construct_from": "diplomatic_capacity_abroad",
+    "construct_to": "transnational_repression_binary",
+    "relationship_type": "moderating",
+    "direction": "positive",
+    "strength": "moderate",
+    "mechanism": "Diplomatic infrastructure provides logistical means to execute TR in host countries, amplifying the domestic repression → TR pathway.",
+    "source_id": "dukalskis_et_al_2024"
+  }
+]
+```
+
+**Required:** construct_from, construct_to, relationship_type
+**relationship_type values:** causal, correlational, mediating, moderating, compositional
+**strength values:** strong, moderate, weak
+
+### Step 9: Create a Playbook (`playbooks/quick_start.yaml`)
+
+A reproducible analysis workflow.
+
+```yaml
+id: quick_start
+display_name: "Quick Start — Transnational Repression"
+description: "Core analysis replicating the main findings."
+estimated_runtime: "1-2 minutes"
+requires_data: true
+
+steps:
+  - id: data_quality_check
+    step: 1
+    display_name: "Data Quality Gate"
+    action: data_quality_gate
+    params:
+      constructs:
+        - transnational_repression_binary
+        - domestic_repression_cli
+      min_observations: 50
+      max_missing_pct: 0.20
+    on_failure: abort
+
+  - id: predictor_correlations
+    step: 2
+    display_name: "Correlations — Key Predictors"
+    engine: correlation_matrix
+    params:
+      variables:
+        - transnational_repression_binary
+        - domestic_repression_cli
+        - diplomatic_capacity_abroad
+    expected_results:
+      transnational_repression_binary↔domestic_repression_cli:
+        direction: positive
+
+  - id: core_logistic
+    step: 3
+    display_name: "Core Model — Logistic Regression"
+    engine: logistic_regression
+    depends_on: [predictor_correlations]
+    params:
+      outcome: transnational_repression_binary
+      predictors:
+        - domestic_repression_cli
+        - diplomatic_capacity_abroad
+    compare_to_kb: true
+    expected_results:
+      domestic_repression_cli:
+        direction: positive
+```
+
+---
+
+## Choosing unit_of_analysis
+
+`unit_of_analysis` (added in v3) is **required for engine compatibility**. It tells engines whether two findings can be pooled, meta-analyzed, or compared. Mixing units (e.g., country-year with individual-level) without declaring them yields apples-to-oranges results, so engines refuse incompatible pools when this is set. Defaulting to `other` defeats the whole point — fill it deliberately on every finding.
+
+### Decision aid
+
+Pick the value that describes ONE row in the underlying analysis dataset:
+
+| If the dataset has one row per… | Use |
+|---------------------------------|-----|
+| Country in a given year (panel data) | `country-year` |
+| Region/state/province in a given year (sub-national panels) | `region-year` (preferred general label), or `province-year` |
+| Municipality / city in a given year | `municipality-year` |
+| County in a given year (US, UK county-level work) | `county-year` |
+| District / sub-district in a given year (often census/health divisions) | `district-year` |
+| Pair of countries in a given year (interstate conflict, trade dyads) | `dyad-year` |
+| Person in a survey or cohort (cross-section) | `individual` |
+| Household in a survey | `household` |
+| Firm (cross-section, no time dimension) | `firm` |
+| Firm-year (annual reporting panels) | `firm-year` |
+| Firm-quarter (quarterly financial panels) | `firm-quarter` |
+| Patient (cross-section, no time dimension) | `patient` |
+| One episode of care for a patient | `patient-episode` |
+| Geographic site / location / facility (cross-section, no time dimension) | `site` |
+| Site-year (facility-level annual panels) | `site-year` |
+| Discrete event (incident, episode, intervention) | `event` |
+| One conflict episode | `conflict-episode` |
+| None of the above clearly fit | `other` (and add a note in `scope_conditions`) |
+
+> **Rule of thumb for "X" vs "X-year".** If the dataset has any time dimension (multiple observations of the same X over years), use the `-year` (or `-quarter`) form. The bare form (`firm`, `patient`, `site`) is reserved for true cross-sections.
+
+### When a paper reports multiple units
+
+If a paper reports several models on different units (e.g., one country-year regression and one individual-level survival model), create **separate findings for each** — one per (effect, unit) pair. Do not collapse them. Engines need to see each effect attached to its own unit so they can decide what's poolable.
+
+### Common mistakes
+
+- **Defaulting to `other`** — only correct if the unit truly doesn't fit any value above. If it's `other`, document why in `scope_conditions`.
+- **Confusing the unit with the construct** — a finding about voter turnout sampled at the individual level is `individual`, even though the construct describes a population-level phenomenon. The unit is the row, not the concept.
+- **Treating `country-year` and `dyad-year` interchangeably** — interstate conflict findings are dyadic; choose `dyad-year`.
+- **Forcing sub-national panels into `country-year`** — a Philippine-province × year regression is `province-year` (or `region-year`), not `country-year`. Engines that pool by unit will treat them as the same level if you mislabel, masking ecological-fallacy risks.
+- **Forcing sub-national panels into `site`** — `site` is reserved for true cross-sections of facilities/locations with no time dimension (e.g., a one-shot RCT site assignment). Sub-national panels with a time axis are `province-year` / `region-year` / `municipality-year` / etc.
+- **Choosing `event` for an annual aggregation of events** — if the rows are years (with event counts as columns), the unit is the temporal aggregation level (`country-year`, `firm-quarter`, etc.), not `event`.
+
+### Why engines care
+
+The data adapter and engine pipeline use `unit_of_analysis` to:
+
+- Refuse to pool findings whose units don't match (without an explicit `force_pool=True` override)
+- Tag KB-comparison output so an agent can see at a glance whether a meta-result is mixing units
+- Block ecological-fallacy traps when `level_bridge` finds a macro/micro construct pair
+
+Setting this correctly is the difference between an engine returning "12 findings agree" and "12 findings agree, all at the country-year level".
+
+---
+
+## Choosing effect_size_type
+
+Pick the value that names what `effect_size_value` actually measures. Mislabeling here forces meta-analysis engines to either drop findings or silently mix incompatible scales.
+
+### Decision aid
+
+| If the headline number is… | Use |
+|----------------------------|-----|
+| Regression coefficient (linear/logit/probit; raw or log-transformed) | `beta` |
+| Odds ratio (logistic, case-control) | `odds_ratio` |
+| Hazard ratio (Cox proportional hazards) | `hazard_ratio` |
+| Risk ratio / relative risk (cohort, RCT) | `risk_ratio` |
+| Incidence rate ratio (Poisson, negative binomial) | `incidence_rate_ratio` |
+| Correlation coefficient (Pearson r, Spearman rho) | `correlation_r` |
+| Cohen's d (standardized mean difference) | `cohens_d` |
+| η² / partial η² (variance-explained from ANOVA) | `eta_squared` |
+| Generic ratio of counts (e.g., "9 nurses per emigrant") | `ratio` |
+| Elasticity (% change in Y per % change in X) | `elasticity` |
+| Semielasticity (% change in Y per unit change in X) | `semielasticity` |
+| Percent change vs. counterfactual (e.g., "+148%") | `percent_change` |
+| Percentage-point change on a 0–100 scale (e.g., "+12 pp") | `percentage_point_change` |
+| dY/dX in natural units (e.g., MPC, marginal effect of price on quantity) | `marginal_effect` |
+| Raw difference in means (unstandardized; e.g., "+\$35,000") | `mean_difference` |
+
+### Common mistakes
+
+- **Labeling an elasticity as `beta`** — A coefficient on a log-log regression is technically a beta, but the finding's meaning is an elasticity. If the paper reports "0.30 manufacturing-output elasticity", use `elasticity` so meta-engines can group with other elasticity findings rather than mixing with raw OLS betas.
+- **Confusing `percent_change` with `percentage_point_change`** — "+148%" is a relative change (`percent_change`); "+12 pp on turnout" is an additive change on a probability scale (`percentage_point_change`). They are not interchangeable.
+- **Using `mean_difference` for standardized differences** — `mean_difference` is the raw, unstandardized difference. If the effect has been divided by a pooled SD, use `cohens_d`.
+- **Defaulting to `other`** — there is no `other` value here. If none of the values fit, leave `effect_size_type` null and put the kind in `effect_size` (text) so a future schema extension can capture it.
+
+---
+
+## Concept vs. Operationalization
+
+Praxis distinguishes **conceptual constructs** (what you are trying to measure) from **operationalizations** (the specific coding rule used to measure it). Two papers that both measure "civil war onset" using different battle-death thresholds (UCDP's 25 vs. Fearon & Laitin 2003's 1000) are operationalizing the same concept differently — they should share a `canonical_id` but each declare its own `operationalization_id`.
+
+### Why this matters
+
+The `canonical_id` is the mechanism that enables cross-PAX bridges to work as **identity** rather than name-matching. Without it, two PAX that both define `civil_war_onset` in their own constructs.json files end up as two unrelated rows in the constructs table — bridges and pathway analysis cannot tell that they refer to the same concept. With it, both rows point at `concept:civil_war_onset` and Praxis can answer "what does the literature say about civil war onset?" by looking through every operationalization across every installed PAX.
+
+### How to declare it
+
+In `knowledge/constructs.json`, each construct entry can carry three additional fields:
+
+```json
+{
+  "id": "civil_war_onset",
+  "display_name": "Civil War Onset",
+  "construct_type": "quantifiable",
+  "definition": "...",
+  "canonical_id": "concept:civil_war_onset",
+  "operationalization_id": "op:civil_war_onset.fl2003_1000_deaths",
+  "coding_rule": "First country-year with cumulative battle-related deaths >= 1000..."
+}
+```
+
+**Rules:**
+
+- If `canonical_id` is declared, the canonical must either already exist in `canonical_constructs` OR be declared in this PAX's `knowledge/canonical_constructs.json`.
+- If `canonical_id` is declared and `operationalization_id` is **not**, the PAX **must** include a `coding_rule` field. The installer will synthesize `op:<canonical_id>.<pax_name>` and write a fresh `construct_operationalizations` row.
+- If you omit `canonical_id` entirely, the construct is created without a canonical link (NULL). Sprint 9 governance is opt-in: existing constructs continue to work unchanged.
+
+### Bootstrapping a new canonical
+
+When you encounter a genuinely new concept that does not yet exist on `pax-market.com`, declare it inline in `knowledge/canonical_constructs.json`:
+
+```json
+[
+  {
+    "id": "concept:civil_war_onset",
+    "display_name": "Civil War Onset",
+    "kind": "outcome",
+    "formal_definition": "The first year of an internal armed conflict between a state government and one or more organized armed groups...",
+    "status": "provisional",
+    "owner": "fearon-laitin-2003"
+  }
+]
+```
+
+The installer loads `canonical_constructs.json` **before** `constructs.json`, so foreign-key references resolve cleanly.
+
+### Construct relations (the lattice)
+
+Use `knowledge/construct_relations.json` to express the lattice of relationships between canonical concepts:
+
+| relation_type | Semantics | Example |
+|---------------|-----------|---------|
+| `refines` | A refines B = A is **more specific** than B (A is a subtype of B). | `concept:civil_war_onset refines concept:armed_conflict_onset` (civil war is a subtype of armed conflict). |
+| `subsumes` | A subsumes B = A is **more general** than B (A encompasses B). The inverse of `refines`. | `concept:armed_conflict_onset subsumes concept:civil_war_onset`. |
+| `disjoint_from` | A and B name distinct, non-overlapping concepts. Bridges and pathways cannot traverse this edge. | `concept:civil_war_onset disjoint_from concept:terrorism_onset`. |
+| `equivalent_to` | A and B refer to the same concept under different names. Treat as identity. | `concept:gdp_per_capita equivalent_to concept:income_per_capita`. |
+
+Direction matters: `refines` and `subsumes` are inverses of each other. `disjoint_from` and `equivalent_to` are symmetric, but the underlying row still has a `from_id` and `to_id` — pick one direction and stick with it.
+
+**Operational consequence of `disjoint_from`:** the lattice is enforced at traversal time, not just as documentation. Both `find_pathways` and `level_bridge` consult `construct_relations` while building their adjacency graphs and **refuse to cross any `disjoint_from` edge** between two canonicals. This means BFS over `find_pathways` will not return a path between two constructs whose canonicals are declared disjoint, and `level_bridge` will not surface a macro/micro bridge if the underlying canonical pair is disjoint. Use `disjoint_from` deliberately — it is a hard separator across the entire graph.
+
+### Governance flow when registering a new construct
+
+When an agent calls `praxis_skill_construct(display_name=..., definition=...)` **without** declaring a `canonical_id`, Praxis runs cosine similarity over `formal_definition` against all existing canonicals:
+
+| Cosine to nearest canonical | Behavior |
+|-----------------------------|----------|
+| ≥ 0.80 | **Reject** with `status='rejected_high_similarity'` and the top 3 candidates. The agent must either (a) re-call with `canonical_id=<existing>` to operationalize the existing canonical, or (b) re-call with `force=True` and a `justification` to override. |
+| 0.70 – 0.79 | Warn but allow. |
+| < 0.70 | Allow. If `PRAXIS_ALLOW_PROVISIONAL_CANONICALS=true`, mint a provisional canonical; otherwise the construct is created with `canonical_id=NULL` (degrade-to-NULL — the default and recommended setting). |
+
+`force=True` always requires a `justification` string. Justifications are written to the `governance_log` table for later audit.
+
+These thresholds (0.80 reject / 0.70 warn) operate on the **canonical layer** only. The existing construct-layer dedup thresholds (0.65 warn / 0.82 auto-merge in `incorporate.py`) are unchanged and continue to govern construct identity within the constructs table.
+
+---
+
+## Validation Checklist
+
+Before submitting your PAX, verify:
+
+### Manifest (`pax.yaml`)
+- [ ] `name` is kebab-case (e.g. `my-research-topic`)
+- [ ] `version` is semver (e.g. `1.0.0`)
+- [ ] `description` is 1-3 sentences
+- [ ] `schema_version` is `"3.0"` (or `"2.0"` for legacy packages without canonical backbone)
+- [ ] `pax_type` is one of: paper, topic, field, enterprise, engine
+- [ ] `provides` lists all entity IDs from knowledge files
+
+### Domain (`domain.json`)
+- [ ] `id` is snake_case
+- [ ] `description` is at least one sentence
+- [ ] `level_of_analysis` is specified
+
+### Constructs (`constructs.json`)
+- [ ] Every construct has a unique snake_case `id`
+- [ ] Every `definition` is at least one full sentence (≥10 characters)
+- [ ] `construct_type` is one of: quantifiable, concept, process, composite, outcome
+- [ ] At least one outcome-type construct exists
+- [ ] `domain_ids` references the domain from domain.json
+- [ ] Aliases included for common abbreviations/synonyms
+- [ ] `measurement_level` specified (nominal/ordinal/interval/ratio)
+
+### Sources (`sources.json`)
+- [ ] Every source has a unique snake_case `id` (pattern: `author_year`)
+- [ ] `methodology_summary` is filled in
+- [ ] `sample_size` is specified
+- [ ] `study_design` is one of the valid values
+
+### Findings (`findings.json`)
+- [ ] Every finding has `source_id` matching a source in sources.json
+- [ ] Every finding has `domain_id` matching the domain
+- [ ] Every finding has at least one `construct_id` from constructs.json
+- [ ] `finding_text` is ≥20 characters and describes ONE specific claim
+- [ ] Null findings included (direction="null") for non-significant results
+- [ ] **Structured statistics populated** when available:
+  - [ ] `effect_size_value` (the numeric coefficient)
+  - [ ] `effect_size_se` (standard error)
+  - [ ] `p_value`
+  - [ ] `sample_size`
+  - [ ] `effect_size_type` specified (beta, odds_ratio, etc.)
+  - [ ] `model_specification` describes the full model
+  - [ ] `covariates_controlled` lists control variables
+- [ ] Fields set to `null` (not omitted) when not available
+
+### Construct Relationships (`construct_relationships.json`)
+- [ ] Every relationship references constructs from constructs.json
+- [ ] `relationship_type` specified
+- [ ] `mechanism` explains how/why
+
+### Cross-File Consistency
+- [ ] All `construct_ids` in findings exist in constructs.json
+- [ ] All `source_id` values in findings exist in sources.json
+- [ ] All construct IDs in relationships exist in constructs.json
+- [ ] `provides` in pax.yaml lists all entity IDs
+
+---
+
+## ID Conventions
+
+| Entity | Pattern | Examples |
+|--------|---------|----------|
+| PAX name | kebab-case | `democratic-peace`, `bartel-comp-materials` |
+| Domain | snake_case | `transnational_repression`, `climate_economics` |
+| Construct | snake_case | `gdp_per_capita`, `civil_war_onset` |
+| Source | author_year | `fearon_laitin_2003`, `dukalskis_et_al_2024` |
+| Proposition | snake_case descriptive | `poverty_increases_conflict_risk` |
+| Playbook | snake_case | `quick_start`, `full_replication` |
+
+---
+
+## Common Mistakes
+
+1. **Findings that summarize instead of claim.** Bad: "The paper studies X." Good: "X increases Y by β=0.34 (p<0.01, N=500)."
+2. **Missing null findings.** If a regression coefficient is not significant, that IS a finding with direction="null".
+3. **Constructs without operationalization.** Always say how it's measured, not just what it means.
+4. **Effect sizes trapped in prose.** Put β=0.34 in `effect_size_value`, not just in `finding_text`.
+5. **Missing covariates.** If the paper controls for GDP, population, etc., list them in `covariates_controlled`.
+6. **Forgetting construct relationships.** If the paper tests A→B, create a relationship entry.
+
+---
+
+## Multi-Source Examples by PAX Type
+
+### Topic PAX: Democratic Peace Theory
+
+A topic PAX synthesizes multiple papers. The key challenge is **construct alignment** — different papers may measure the same concept differently.
+
+```yaml
+# pax.yaml
+name: democratic-peace
+pax_type: topic
+description: "Why democracies rarely fight each other — regime type, economic interdependence, and international organizations."
+```
+
+**Sources:** 5 papers (Doyle 1986, Maoz & Russett 1993, Oneal & Russett 1999, Gartzke 2007, Hegre 2014)
+**Constructs:** `joint_democracy` (quantifiable), `mid_onset` (outcome), `trade_interdependence` (quantifiable), `igo_membership_overlap` (quantifiable), `capitalist_peace` (concept)
+**Findings:** 15 findings across 5 papers — some agree (democracy reduces MID), some contest (Gartzke: it's capitalism, not democracy)
+**Propositions:** "Joint democracy reduces interstate conflict" with scope_conditions="post-1945 dyads"
+
+**Key pattern:** The same construct (`joint_democracy`) appears in multiple sources with different operationalizations. Use `measures` to list them all and `aliases` for variant names.
+
+### Field PAX: Computational Materials Science
+
+A field PAX covers an entire research program. Expect sub-domains.
+
+```json
+// domain.json — primary domain
+{
+  "id": "bartel_comp_materials",
+  "display_name": "Bartel Computational Materials Science",
+  "description": "ML for property prediction, autonomous synthesis, perovskite stability, battery materials..."
+}
+
+// Additional domains with parent linkage:
+[
+  {"id": "perovskite_stability", "parent_domain_id": "bartel_comp_materials", ...},
+  {"id": "battery_materials", "parent_domain_id": "bartel_comp_materials", ...},
+  {"id": "autonomous_synthesis", "parent_domain_id": "bartel_comp_materials", ...}
+]
+```
+
+**Key pattern:** Use `parent_domain_id` to organize sub-domains. Constructs and findings spread across sub-domains. The export system will collect all child domains automatically.
+
+### Enterprise PAX: SaaS Churn
+
+```yaml
+name: saas-customer-churn
+pax_type: enterprise
+description: "Customer churn prediction and retention drivers for B2B SaaS."
+```
+
+```json
+// constructs.json
+[
+  {
+    "id": "monthly_churn_rate",
+    "display_name": "Monthly Churn Rate",
+    "construct_type": "outcome",
+    "definition": "Percentage of paying customers who cancel or don't renew in a given month.",
+    "operational_definition": "Churned customers / total active customers at month start × 100",
+    "measurement_level": "ratio",
+    "measures": ["Stripe subscription cancellation events", "Manual cancellation tracking in CRM"]
+  },
+  {
+    "id": "feature_adoption_score",
+    "display_name": "Feature Adoption Score",
+    "construct_type": "quantifiable",
+    "definition": "Composite score (0-100) measuring how many core product features a customer actively uses.",
+    "operational_definition": "Count of distinct core features used in last 30 days / total core features × 100",
+    "measurement_level": "ratio"
+  }
+]
+
+// findings.json
+[
+  {
+    "source_id": "internal_analysis_2026q1",
+    "domain_id": "saas_customer_churn",
+    "finding_text": "Feature adoption score > 60% reduces monthly churn by 40% compared to low-adoption cohort.",
+    "construct_ids": ["feature_adoption_score", "monthly_churn_rate"],
+    "direction": "negative",
+    "confidence": "strong",
+    "effect_size_value": 0.60,
+    "effect_size_type": "odds_ratio",
+    "sample_size": 5000,
+    "p_value": 0.001,
+    "model_specification": "logistic regression with cohort and tenure controls",
+    "covariates_controlled": ["customer_tenure_months", "plan_tier", "company_size"]
+  }
+]
+```
+
+**Key pattern:** Enterprise PAX often has `dataset` or `manual` source types and findings from internal analyses rather than published papers.
+
+---
+
+## Packaging & Distribution Format
+
+For sharing, archival, marketplace submission, or cross-machine transfer, a PAX is distributed as a single gzip-compressed tarball with the extension `.pax.tar.gz`.
+
+### Archive layout
+
+The tarball flattens the PAX directory at its root and adds one file — `manifest.json` — at the top level:
+
+```
+<pax_name>.pax.tar.gz
+├── manifest.json                   # Archive metadata + per-file sha256 + size
+├── pax.yaml
+├── knowledge/
+│   ├── domain.json
+│   ├── constructs.json
+│   ├── sources.json
+│   ├── findings.json
+│   ├── propositions.json
+│   ├── construct_relationships.json
+│   ├── canonical_constructs.json   # v3
+│   └── construct_relations.json    # v3
+└── playbooks/
+    └── quick_start.yaml
+```
+
+> **Note.** `manifest.json` (archive metadata) is distinct from `pax.yaml` (the PAX manifest). Both live at the archive root; only `pax.yaml` is authored by you.
+
+### `manifest.json` schema
+
+```json
+{
+  "pax_name": "dukalskis-et-al-2024-transnational-repression",
+  "version": "1.0.0",
+  "exported_at": "2026-04-28T12:34:56Z",
+  "exported_by": "praxis",
+  "files": {
+    "pax.yaml": { "sha256": "8a7b...e3", "size": 1284 },
+    "knowledge/domain.json": { "sha256": "12cf...91", "size": 4102 },
+    "knowledge/constructs.json": { "sha256": "44ee...0a", "size": 18733 },
+    "knowledge/canonical_constructs.json": { "sha256": "9d10...77", "size": 2950 },
+    "knowledge/construct_relations.json": { "sha256": "ab2c...41", "size": 612 }
+  }
+}
+```
+
+Every file shipped in the archive (except `manifest.json` itself) MUST appear in `files` with a SHA-256 hex digest and byte size. `import_pax` recomputes each digest on receipt and refuses the archive on any mismatch — this is the integrity boundary between authoring and consumption.
+
+### How to produce the archive
+
+**Recommended (round-trip via Praxis):**
+
+```bash
+# Install your authored directory locally first
+praxis_install_pax(pax_dir="/path/to/my-pax-name")
+
+# Then export — this is the canonical packaging step (computes sha256s, builds manifest.json, tars+gzips)
+praxis_export_pax(pax_name="my-pax-name", output_dir="/path/to/output")
+# Returns: { archive_path, size_bytes, file_count, checksum }
+```
+
+`export_pax` always reconstructs the archive contents from the database, not the filesystem — so any normalization, ID rewrites, or `extend_pax` additions made after install are reflected in the export.
+
+**Manual (offline, no Praxis runtime):**
+
+```bash
+cd /path/to/my-pax-name
+# Compute per-file sha256 + size, write manifest.json at the root, then:
+tar -czf ../my-pax-name.pax.tar.gz manifest.json pax.yaml knowledge/ playbooks/
+sha256sum ../my-pax-name.pax.tar.gz   # archive-level checksum (record this for your registry entry)
+```
+
+The marketplace upload service at [submit.pax-market.com](https://submit.pax-market.com) accepts either a directory upload (it packages for you) or a pre-built `.pax.tar.gz`.
+
+### Archive integrity rules
+
+- **Filename** — Must be `<pax_name>.pax.tar.gz`. The leading segment must match `pax.yaml`'s `name` field.
+- **No path traversal** — Tar entries with `..`, absolute paths, or symlinks are rejected by `import_pax`.
+- **No extra files** — Anything not listed in `manifest.json["files"]` triggers a validation warning. `manifest.json` itself is excluded from the file map.
+- **Compression** — Must be gzip (`.tar.gz`), not bzip2 or xz. The mime type is `application/gzip`.
+- **Size guidance** — Most paper PAXes are <100 KB compressed; field PAXes (50+ sources) typically 1–5 MB. Hard ceiling enforced by the marketplace upload service is 50 MB.
+
+---
+
+## What Happens Next
+
+Once you have the files (and optionally the `.pax.tar.gz`):
+
+1. **Validate offline** — Check against the checklist above
+2. **Import into Praxis** — Use `praxis_import_pax` (archive) or `praxis_install_pax` (directory)
+3. **Or publish** — Submit to the PAX marketplace at [pax-market.com](https://pax-market.com)
+4. **Agents use it** — Any Praxis-connected agent can install the PAX and immediately run analyses
+
+The PAX is the unit of portable expertise. Build it once, use it everywhere.
+
+---
+
+## Controlled Vocabularies Reference
+
+These are the canonical enum values for all PAX fields. The Praxis codebase parses this section at runtime — changes here propagate automatically to validation, MCP tool schemas, and LLM extraction prompts.
+
+<!-- PAX_SCHEMA_START — do not remove this marker -->
+
+**pax_type values:** paper, topic, field, enterprise, engine
+
+**source_type values:** academic_paper, journal_article, book, book_chapter, working_paper, report, dataset, manual, synthetic
+
+**construct_type values:** quantifiable, concept, process, composite, outcome
+
+**direction values:** positive, negative, null, conditional, unknown
+
+**confidence values:** strong, moderate, weak, foundational, unknown
+
+**finding_type values:** empirical, theoretical, normative, mechanism, methodological
+
+**evidence_type values:** quantitative, qualitative, mixed, theoretical, exploratory
+
+**finding_state values:** provisional, confirmed, contested, superseded, retracted
+
+**level_of_analysis values:** micro, meso, macro, cross-level, dyadic
+
+**measurement_level values:** nominal, ordinal, interval, ratio
+
+**relationship_type values:** causal, correlational, mediating, moderating, compositional
+
+**study_design values:** rct, quasi_experimental, observational_longitudinal, observational_cross_sectional, case_study, meta_analysis, review, theoretical
+
+**effect_size_type values:** beta, odds_ratio, hazard_ratio, risk_ratio, incidence_rate_ratio, correlation_r, cohens_d, eta_squared, ratio, elasticity, semielasticity, percent_change, percentage_point_change, marginal_effect, mean_difference
+
+**strength values:** strong, moderate, weak
+
+**alias_type values:** synonym, abbreviation, operationalization
+
+**unit_of_analysis values:** country-year, region-year, province-year, municipality-year, county-year, district-year, dyad-year, individual, household, firm, firm-year, firm-quarter, patient, patient-episode, site, site-year, event, conflict-episode, other
+
+**relation_type values:** subsumes, refines, disjoint_from, equivalent_to
+
+**operationalization_status values:** active, deprecated
+
+**canonical_status values:** provisional, canonical, deprecated
+
+**construct_kind values:** quantifiable, concept, process, composite, outcome
+
+<!-- PAX_SCHEMA_END — do not remove this marker -->
+
+---
+
+## Machine-Readable Field Manifest
+
+This section is parsed at runtime by `pax_schema.get_entity_fields()`. It defines
+required, recommended, and optional fields for each PAX knowledge entity.
+
+<!-- PAX_FIELDS_START -->
+```yaml
+entities:
+  pax_yaml:
+    required: [name, version, description, schema_version, pax_type]
+    recommended: [author, tags, provides, engines]
+    optional: [dependencies, registry_url, domain_id]
+
+  domain:
+    required: [id, display_name, description]
+    recommended: [temporal_scope, population, level_of_analysis]
+    optional: [research_questions, parent_domain_id]
+
+  source:
+    required: [id, source_type, title]
+    recommended:
+      - {name: methodology_summary, type: text}
+      - {name: sample_size, type: integer}
+      - {name: population_description, type: text}
+      - {name: study_design, type: enum, enum: STUDY_DESIGNS}
+      - {name: key_limitations, type: text}
+      - {name: replication_status, type: text}
+      - {name: data_availability, type: text}
+      - {name: journal, type: text}
+      - {name: url, type: text}
+    optional: [authors, year, doi, abstract]
+
+  construct:
+    required: [id, display_name, construct_type, definition]
+    recommended:
+      - {name: formal_definition, type: text}
+      - {name: operational_definition, type: text}
+      - {name: measurement_level, type: enum, enum: MEASUREMENT_LEVELS}
+      - {name: aliases, type: list}
+      - {name: measures, type: list}
+      - {name: domain_ids, type: list}
+    optional: [parent_construct_id, validity_notes, provenance_json, source_id, canonical_id, operationalization_id]
+
+  finding:
+    required: [source_id, domain_id, finding_text, construct_ids, direction]
+    recommended:
+      - {name: confidence, type: enum, enum: CONFIDENCE_VALUES}
+      - {name: finding_type, type: enum, enum: FINDING_TYPES}
+      - {name: evidence_type, type: enum, enum: EVIDENCE_TYPES}
+      - {name: unit_of_analysis, type: enum, enum: UNIT_OF_ANALYSIS}
+      - {name: scope_conditions, type: text}
+      - {name: sample_n, type: integer}
+      - {name: effect_size_value, type: number}
+      - {name: effect_size_se, type: number}
+      - {name: p_value, type: number}
+      - {name: ci_lower, type: number}
+      - {name: ci_upper, type: number}
+      - {name: effect_size_type, type: enum, enum: EFFECT_SIZE_TYPES}
+    optional: [method_used, sample_size, r_squared, model_specification, covariates_controlled, state]
+
+  proposition:
+    required: [id, proposition_text, construct_from, construct_to]
+    recommended:
+      - {name: direction, type: enum, enum: DIRECTION_VALUES}
+      - {name: theoretical_basis, type: text}
+      - {name: scope_conditions, type: text}
+    optional: [domain_id, status, source_id]
+
+  construct_relationship:
+    required: [construct_from, construct_to, relationship_type]
+    recommended:
+      - {name: direction, type: enum, enum: DIRECTION_VALUES}
+      - {name: strength, type: enum, enum: STRENGTH_VALUES}
+      - {name: mechanism, type: text}
+    optional: [source_id]
+
+  construct_alias:
+    required: [construct_id, alias]
+    recommended:
+      - {name: alias_type, type: enum, enum: ALIAS_TYPES}
+      - {name: source_id, type: text}
+      - {name: pax_name, type: text}
+    optional: [added_at]
+
+  construct_measure:
+    required: [construct_id, measure_description]
+    recommended:
+      - {name: unit, type: text}
+      - {name: scale_description, type: text}
+      - {name: source_id, type: text}
+      - {name: pax_name, type: text}
+    optional: [added_at]
+
+  construct_evidence:
+    required: [construct_id, source_id, contribution_type]
+    recommended:
+      - {name: pax_name, type: text}
+    optional: [added_at]
+
+  dataset_variable:
+    required: [source_id, column_name]
+    recommended:
+      - {name: construct_id, type: text}
+      - {name: description, type: text}
+      - {name: units, type: text}
+      - {name: scale_type, type: text}
+      - {name: table_name, type: text}
+    optional: [notes, priority, operationalization_notes]
+
+  canonical_construct:
+    required: [id, display_name, kind, formal_definition]
+    recommended:
+      - {name: status, type: text}
+      - {name: unit_kind, type: text}
+      - {name: owner, type: text}
+    optional: [superseded_by]
+
+  construct_operationalization:
+    required: [id, canonical_id, display_name, coding_rule]
+    recommended:
+      - {name: measurement_level, type: enum, enum: MEASUREMENT_LEVELS}
+      - {name: source_id, type: text}
+      - {name: status, type: text}
+    optional: [threshold_json, unit]
+
+  construct_relation:
+    required: [from_id, to_id, relation_type]
+    recommended:
+      - {name: justification, type: text}
+      - {name: source_id, type: text}
+    optional: [pax_name]
+```
+<!-- PAX_FIELDS_END -->
+
+---
+
+## Version History
+
+This document is the canonical PAX specification. All schema changes are recorded here.
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 3.0 | 2026-04-28 | Canonical-construct backbone (`canonical_constructs.json`, `construct_relations.json`). Operationalization split — `constructs.json` entries gain `canonical_id`, `operationalization_id`, `operationalization_status`, `coding_rule`. Backbone `relation_type` controlled vocabulary (`subsumes`, `refines`, `disjoint_from`, `equivalent_to`). `unit_of_analysis` on findings (engine pooling/dedup). Minting governance — provisional → canonical promotion logged in `governance_log` with justification. `find_pathways` and `level_bridge` honor `disjoint_from` to block cross-cluster traversal. Sprints 7–9. |
+| 2.0 | 2026-04-07 | Structured statistics on findings (effect_size_value, SE, p, N, CI, model_spec, covariates). Enriched source metadata (methodology, study_design, sample_size, limitations, replication). Construct provenance (formal/operational definitions, measurement_level, provenance chain). Construct relationships (causal/correlational with mechanism). Engine documentation (parameters, assumptions, diagnostics, interpretation). Playbook enhancements (data quality gates, conditional branching, parameter variants). Quality scoring adds statistical_richness, relationship_coverage, source_depth sub-scores. See ADR-007. |
+| 1.0 | 2026-04-05 | Initial PAX format: manifest, domain, constructs (with aliases/measures), sources, findings, propositions, playbooks, engine registry, data sources. |
+
+### Planned for v3.1
+- Finding TTL/expiration for business metrics that decay
+- Data freshness requirements on playbook steps
+- KPI constructs with target_value and threshold fields
+- Construct scope (org-specific vs. universal)
+- Cross-PAX canonical reconciliation (auto-detect when two PAXes use different canonical IDs for the same concept)

--- a/docs/PAX_USAGE_GUIDE.md
+++ b/docs/PAX_USAGE_GUIDE.md
@@ -1,0 +1,501 @@
+# PAX Usage Guide — For Any LLM or Agent
+
+> **What is this?** A generic guide for using any Praxis PAX (Portable Analytical eXpertise) package. Feed this document + a downloaded PAX to any LLM or agent, and it can reason over the knowledge, synthesize findings, and — if code-capable — run analyses.
+>
+> **Companion to:** `PAX_CREATION_GUIDE.md` (how to *build* a PAX). This guide is how to *use* one.
+
+---
+
+## What's in a PAX?
+
+A PAX is a directory of YAML and JSON files containing structured domain knowledge. Every PAX follows the same structure:
+
+```
+my-pax-name/
+├── pax.yaml                           # Manifest — what this PAX covers
+├── knowledge/
+│   ├── domain.json (or domains.json)  # Research domain definition(s)
+│   ├── constructs.json                # Variables and concepts
+│   ├── sources.json                   # Papers, datasets, other references
+│   ├── findings.json                  # Empirical claims with statistics
+│   ├── propositions.json              # Theoretical claims (optional)
+│   └── construct_relationships.json   # Causal/correlational links (optional)
+└── playbooks/
+    └── quick_start.yaml               # Reproducible analysis workflow (optional)
+```
+
+---
+
+## Understanding Each File
+
+### `pax.yaml` — The Manifest
+
+Tells you what this PAX is about. Key fields:
+- `name`: unique identifier (kebab-case)
+- `description`: what the PAX covers
+- `pax_type`: paper (single study), topic (multiple papers), field (whole discipline), enterprise (business domain)
+- `provides`: lists of all construct IDs, source IDs, finding IDs in the package
+
+### `knowledge/constructs.json` — The Building Blocks
+
+An array of **constructs** — the atomic concepts, variables, and measures in this domain. Each has:
+
+| Field | What It Tells You |
+|-------|-------------------|
+| `id` | Unique identifier (snake_case) |
+| `display_name` | Human-readable name |
+| `construct_type` | quantifiable, concept, process, composite, or outcome |
+| `definition` | What this construct means |
+| `formal_definition` | Precise academic definition (if available) |
+| `operational_definition` | How it's actually measured in practice |
+| `measurement_level` | nominal, ordinal, interval, or ratio |
+| `aliases` | Alternative names and abbreviations |
+| `measures` | How it's operationalized (specific instruments/data sources) |
+
+**How to use constructs:** These are your vocabulary. When reasoning about the domain, use these construct IDs to connect findings, relationships, and propositions. If you're asked about something not in the construct list, say so — it may be a gap.
+
+### `knowledge/sources.json` — Where the Knowledge Comes From
+
+An array of papers, datasets, and other references. Each has:
+
+| Field | What It Tells You |
+|-------|-------------------|
+| `id` | Source identifier (author_year pattern) |
+| `title` | Full title |
+| `authors`, `year`, `doi` | Citation metadata |
+| `methodology_summary` | How the study was conducted |
+| `sample_size` | N |
+| `study_design` | rct, quasi_experimental, observational_longitudinal, etc. |
+| `key_limitations` | Known weaknesses |
+| `replication_status` | replicated, failed_replication, not_attempted, unknown |
+
+**How to use sources:** When citing findings, always reference the source. Use `methodology_summary` and `study_design` to assess evidence quality. Note limitations when they affect the finding's reliability.
+
+### `knowledge/findings.json` — What We Know
+
+An array of **findings** — specific empirical claims linking constructs. This is the most important file. Each finding has:
+
+| Field | What It Tells You |
+|-------|-------------------|
+| `finding_text` | Natural language description of the claim |
+| `construct_ids` | Which constructs are involved |
+| `direction` | positive, negative, null, conditional, unknown |
+| `confidence` | strong, moderate, weak, foundational, unknown |
+| `effect_size` | Narrative summary of the effect |
+| `method_used` | Statistical method and sample |
+
+**Structured statistics** (when available — use these for precise reasoning):
+
+| Field | What It Tells You |
+|-------|-------------------|
+| `effect_size_value` | Numeric coefficient (β, OR, r, d, etc.) |
+| `effect_size_se` | Standard error of the estimate |
+| `p_value` | Statistical significance |
+| `sample_size` | N for this specific finding |
+| `r_squared` | Model fit (R²) |
+| `ci_lower`, `ci_upper` | Confidence interval bounds |
+| `effect_size_type` | What kind of effect: beta, odds_ratio, hazard_ratio, correlation_r, cohens_d |
+| `model_specification` | Full model description |
+| `covariates_controlled` | What was controlled for |
+
+**How to use findings:**
+- Group by construct pair to see consensus/contradiction
+- Weight by confidence level and sample size
+- Note null findings (direction="null") — non-significance IS evidence
+- Use structured statistics for precise comparisons when available
+
+### `knowledge/propositions.json` — What Theory Says
+
+Formal theoretical claims linking two constructs. Each has:
+- `proposition_text`: the claim itself
+- `construct_from` / `construct_to`: cause → effect
+- `direction`: positive, negative, conditional, contested
+- `theoretical_basis`: which theory supports this
+- `scope_conditions`: when/where this holds
+
+**How to use propositions:** These are the theoretical framework. Compare propositions to findings — does the evidence support the theory? Where are the gaps between what theory predicts and what evidence shows?
+
+### `knowledge/construct_relationships.json` — The Causal Map
+
+Explicit relationships between constructs:
+- `construct_from` → `construct_to`
+- `relationship_type`: causal, correlational, mediating, moderating, compositional
+- `mechanism`: how/why the relationship operates
+- `strength`: strong, moderate, weak
+
+**How to use relationships:** These form a causal graph. Trace pathways from predictors to outcomes. Identify mediators and moderators. When asked "how does X affect Y?", follow the relationship chain and cite the mechanisms.
+
+### `playbooks/*.yaml` — Analysis Recipes
+
+Reproducible analysis workflows with steps like:
+- Correlation matrices
+- Regression models
+- Data quality checks
+- Expected results and validation criteria
+
+**How to use playbooks:** See Tier 2 (code-capable agents) below for execution instructions.
+
+---
+
+## Tier 1: Knowledge Synthesis (Any LLM, No Code)
+
+These tasks require only reading and reasoning over the JSON files. Any LLM can do them.
+
+### Evidence Synthesis
+
+**Prompt:** "Based on this PAX's findings, what does the evidence say about [construct X]?"
+
+**How to answer:**
+1. Find all findings where `construct_ids` includes the target construct
+2. Group by direction (positive, negative, null)
+3. Weight by confidence level (strong > moderate > weak)
+4. Note the methods used and sample sizes
+5. Flag contradictions where findings disagree
+6. Cite sources for each claim
+
+### Gap Identification
+
+**Prompt:** "What are the knowledge gaps in this PAX?"
+
+**How to answer:**
+1. Find constructs that appear in no findings → unmeasured concepts
+2. Find construct pairs in `construct_relationships` with no corresponding findings → untested relationships
+3. Find propositions with no supporting findings → unvalidated theories
+4. Check for constructs with only one source → single-study evidence
+5. Look for constructs with weak/unknown confidence only → uncertain areas
+
+### Causal Chain Analysis
+
+**Prompt:** "Trace the causal pathway from [A] to [B]"
+
+**How to answer:**
+1. Start with construct A in `construct_relationships`
+2. Follow outgoing relationships until you reach B
+3. At each link, cite the mechanism and supporting findings
+4. Note the strength of each link (strong/moderate/weak)
+5. Identify the weakest link in the chain
+
+### Evidence Comparison
+
+**Prompt:** "Does [external claim] agree with this PAX's evidence?"
+
+**How to answer:**
+1. Identify which constructs the claim involves
+2. Find all relevant findings in the PAX
+3. Compare the claimed direction and magnitude against findings
+4. Note whether the claim's methodology is similar to the PAX's sources
+5. Assess whether scope conditions match
+
+### Meta-Level Assessment
+
+**Prompt:** "How mature is the evidence in this PAX?"
+
+**How to answer:**
+1. Count findings by confidence level
+2. Count constructs with vs. without findings
+3. Check replication_status of sources (replicated > not_attempted)
+4. Assess methodological diversity (multiple study_design types = stronger)
+5. Note the temporal range (old findings may be outdated)
+
+---
+
+## Tier 2: Running Analyses (Code-Capable Agents)
+
+If your agent can execute Python (Claude Code, OpenAI Codex, Google Gemini with code), you can set up a local database and run playbook analyses.
+
+### Step 1: Set Up SQLite Database
+
+```python
+import sqlite3
+import json
+
+conn = sqlite3.connect("pax_knowledge.db")
+conn.row_factory = sqlite3.Row
+c = conn.cursor()
+
+# Create tables
+c.executescript("""
+CREATE TABLE IF NOT EXISTS constructs (
+    id TEXT PRIMARY KEY,
+    display_name TEXT NOT NULL,
+    construct_type TEXT,
+    definition TEXT,
+    formal_definition TEXT,
+    operational_definition TEXT,
+    measurement_level TEXT
+);
+
+CREATE TABLE IF NOT EXISTS sources (
+    id TEXT PRIMARY KEY,
+    source_type TEXT,
+    title TEXT NOT NULL,
+    authors TEXT,
+    year INTEGER,
+    methodology_summary TEXT,
+    sample_size INTEGER,
+    study_design TEXT
+);
+
+CREATE TABLE IF NOT EXISTS findings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id TEXT,
+    domain_id TEXT,
+    finding_text TEXT NOT NULL,
+    construct_ids TEXT,
+    direction TEXT,
+    effect_size TEXT,
+    confidence TEXT,
+    effect_size_value REAL,
+    effect_size_se REAL,
+    p_value REAL,
+    sample_size INTEGER,
+    r_squared REAL,
+    effect_size_type TEXT,
+    model_specification TEXT,
+    FOREIGN KEY (source_id) REFERENCES sources(id)
+);
+
+CREATE TABLE IF NOT EXISTS construct_relationships (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    construct_from TEXT,
+    construct_to TEXT,
+    relationship_type TEXT,
+    direction TEXT,
+    strength TEXT,
+    mechanism TEXT
+);
+
+CREATE TABLE IF NOT EXISTS propositions (
+    id TEXT PRIMARY KEY,
+    proposition_text TEXT,
+    construct_from TEXT,
+    construct_to TEXT,
+    direction TEXT,
+    theoretical_basis TEXT,
+    scope_conditions TEXT
+);
+""")
+```
+
+### Step 2: Load Knowledge Files
+
+```python
+def load_json(path):
+    with open(path) as f:
+        data = json.load(f)
+    return data if isinstance(data, list) else [data]
+
+# Load constructs
+for c in load_json("knowledge/constructs.json"):
+    conn.execute(
+        "INSERT OR IGNORE INTO constructs (id, display_name, construct_type, definition, "
+        "formal_definition, operational_definition, measurement_level) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (c["id"], c["display_name"], c.get("construct_type"),
+         c.get("definition"), c.get("formal_definition"),
+         c.get("operational_definition"), c.get("measurement_level"))
+    )
+
+# Load sources
+for s in load_json("knowledge/sources.json"):
+    conn.execute(
+        "INSERT OR IGNORE INTO sources (id, source_type, title, authors, year, "
+        "methodology_summary, sample_size, study_design) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (s["id"], s.get("source_type"), s["title"], s.get("authors"),
+         s.get("year"), s.get("methodology_summary"),
+         s.get("sample_size"), s.get("study_design"))
+    )
+
+# Load findings
+for f in load_json("knowledge/findings.json"):
+    cids = f.get("construct_ids", [])
+    if isinstance(cids, list):
+        cids = ",".join(cids)
+    conn.execute(
+        "INSERT INTO findings (source_id, domain_id, finding_text, construct_ids, "
+        "direction, effect_size, confidence, effect_size_value, effect_size_se, "
+        "p_value, sample_size, r_squared, effect_size_type, model_specification) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (f.get("source_id"), f.get("domain_id"), f["finding_text"], cids,
+         f.get("direction"), f.get("effect_size"), f.get("confidence"),
+         f.get("effect_size_value"), f.get("effect_size_se"),
+         f.get("p_value"), f.get("sample_size"), f.get("r_squared"),
+         f.get("effect_size_type"), f.get("model_specification"))
+    )
+
+# Load relationships
+import os
+if os.path.exists("knowledge/construct_relationships.json"):
+    for r in load_json("knowledge/construct_relationships.json"):
+        conn.execute(
+            "INSERT INTO construct_relationships (construct_from, construct_to, "
+            "relationship_type, direction, strength, mechanism) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (r["construct_from"], r["construct_to"], r["relationship_type"],
+             r.get("direction"), r.get("strength"), r.get("mechanism"))
+        )
+
+# Load propositions
+if os.path.exists("knowledge/propositions.json"):
+    for p in load_json("knowledge/propositions.json"):
+        conn.execute(
+            "INSERT OR IGNORE INTO propositions (id, proposition_text, construct_from, "
+            "construct_to, direction, theoretical_basis, scope_conditions) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (p["id"], p["proposition_text"], p.get("construct_from"),
+             p.get("construct_to"), p.get("direction"),
+             p.get("theoretical_basis"), p.get("scope_conditions"))
+        )
+
+conn.commit()
+print(f"Loaded: {conn.execute('SELECT COUNT(*) FROM constructs').fetchone()[0]} constructs, "
+      f"{conn.execute('SELECT COUNT(*) FROM findings').fetchone()[0]} findings, "
+      f"{conn.execute('SELECT COUNT(*) FROM sources').fetchone()[0]} sources")
+```
+
+### Step 3: Query the Knowledge Base
+
+```python
+# Find all findings about a specific construct
+def findings_for(construct_id):
+    return conn.execute(
+        "SELECT * FROM findings WHERE construct_ids LIKE ?",
+        (f"%{construct_id}%",)
+    ).fetchall()
+
+# Get the causal graph
+def causal_graph():
+    return conn.execute(
+        "SELECT construct_from, construct_to, relationship_type, direction, strength, mechanism "
+        "FROM construct_relationships"
+    ).fetchall()
+
+# Evidence consensus for a construct pair
+def consensus(construct_a, construct_b):
+    rows = conn.execute(
+        "SELECT direction, confidence, effect_size_value, source_id "
+        "FROM findings WHERE construct_ids LIKE ? AND construct_ids LIKE ?",
+        (f"%{construct_a}%", f"%{construct_b}%")
+    ).fetchall()
+    return rows
+```
+
+### Step 4: Run Playbook Analyses
+
+Playbooks are YAML files with analysis steps. Each step specifies an engine and parameters.
+
+```python
+import yaml
+
+# Load a playbook
+with open("playbooks/quick_start.yaml") as f:
+    playbook = yaml.safe_load(f)
+
+print(f"Playbook: {playbook.get('display_name', playbook.get('id'))}")
+print(f"Steps: {len(playbook.get('steps', []))}")
+
+for step in playbook.get("steps", []):
+    print(f"\n--- Step: {step.get('display_name', step.get('id'))} ---")
+    engine = step.get("engine", step.get("action"))
+    params = step.get("params", {})
+    print(f"Engine: {engine}")
+    print(f"Params: {params}")
+    expected = step.get("expected_results", {})
+    if expected:
+        print(f"Expected: {expected}")
+```
+
+**Running a correlation matrix:**
+```python
+import pandas as pd
+import numpy as np
+
+# Get findings with numeric effect sizes for a set of constructs
+constructs_of_interest = params.get("variables", [])
+
+# Query findings
+findings_data = []
+for cid in constructs_of_interest:
+    rows = findings_for(cid)
+    for r in rows:
+        if r["effect_size_value"] is not None:
+            findings_data.append({
+                "construct": cid,
+                "effect_size": r["effect_size_value"],
+                "source": r["source_id"],
+                "direction": r["direction"],
+            })
+
+if findings_data:
+    df = pd.DataFrame(findings_data)
+    print(df.groupby("construct")["effect_size"].describe())
+```
+
+**Running a regression (if you have raw data):**
+```python
+# If the PAX includes data or you've downloaded it:
+import statsmodels.api as sm
+
+# Example: OLS regression
+outcome = params.get("outcome")
+predictors = params.get("predictors", [])
+
+# Load data (from data/ directory or external source)
+# data = pd.read_csv("data/cache/your_data.csv")
+# X = data[predictors]
+# y = data[outcome]
+# model = sm.OLS(y, sm.add_constant(X)).fit()
+# print(model.summary())
+```
+
+### Step 5: Compare Results to KB Findings
+
+After running an analysis, compare your results to the PAX's findings:
+
+```python
+def compare_to_kb(your_beta, your_p, construct_a, construct_b):
+    """Compare your analysis result to what the KB says."""
+    kb_findings = consensus(construct_a, construct_b)
+    
+    print(f"\nYour result: β={your_beta:.3f}, p={your_p:.4f}")
+    print(f"KB has {len(kb_findings)} relevant finding(s):\n")
+    
+    for f in kb_findings:
+        kb_beta = f["effect_size_value"]
+        if kb_beta is not None:
+            diff = abs(your_beta - kb_beta)
+            print(f"  KB: β={kb_beta:.3f} ({f['direction']}, {f['confidence']})")
+            print(f"  Δ = {diff:.3f} — {'consistent' if diff < 0.2 else 'DIVERGENT'}")
+        else:
+            print(f"  KB: {f['direction']} ({f['confidence']}) — no numeric effect size")
+```
+
+---
+
+## Common Questions
+
+**Q: How do I know if a PAX is high quality?**
+Check: Does it have findings with structured statistics (effect_size_value, p_value)? Are sources well-documented (methodology_summary, study_design)? Does it have construct relationships? Does it have multiple sources? The more of these it has, the richer the PAX.
+
+**Q: Can I combine multiple PAX?**
+Yes — if constructs share the same IDs across PAX, their findings can be compared. Load multiple PAX into the same SQLite database. Constructs with the same ID represent the same concept.
+
+**Q: What if a PAX has no playbooks?**
+You can still do everything in Tier 1 (knowledge synthesis). For analysis, use the construct definitions and relationships to design your own analysis — the PAX tells you *what to measure* and *what to expect*, even without a playbook.
+
+**Q: What's the relationship between this guide and Praxis?**
+Praxis is the full runtime — PostgreSQL, MCP tools, 19 statistical engines, semantic search. This guide enables a lightweight subset using just the knowledge files. For full analytical capability (engine execution, KB comparison, data resolution), install Praxis and use `praxis_install_pax`.
+
+---
+
+## Quick Reference: File → What You Can Do
+
+| File | Tier 1 (No Code) | Tier 2 (Code) |
+|------|-------------------|---------------|
+| `constructs.json` | Understand the domain vocabulary | Query by type, find gaps |
+| `sources.json` | Assess evidence quality | Filter by design, year |
+| `findings.json` | Synthesize evidence, find consensus | Statistical comparison, meta-analysis |
+| `propositions.json` | Evaluate theoretical claims | Test against findings |
+| `construct_relationships.json` | Trace causal chains | Build causal graphs |
+| `playbooks/*.yaml` | Understand expected analyses | Execute with pandas/statsmodels |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# PAX Documentation (Canonical)
+
+This is the canonical home of the PAX authoring/usage guides.
+
+## Files
+
+- **`PAX_CREATION_GUIDE.md`** — How to author a PAX (manifest, constructs, findings, sources, playbooks, schema enums). The single source of truth for the schema. Edit here.
+- **`PAX_USAGE_GUIDE.md`** — How to consume a published PAX (install, run engines, reproduce findings). Edit here.
+
+## How edits propagate
+
+1. Edit a guide in this directory and open a PR. CI validates the `<!-- PAX_SCHEMA_START -->` and `<!-- PAX_FIELDS_START -->` markers are intact.
+2. On merge to `main`, `publish-artifacts.yml` creates a fresh `latest` GitHub Release with both guides as assets, alongside the existing registry artifacts.
+3. **pax-website** (the marketplace site) fetches the guides from the release on its next build cycle (~5 min via the homelab autodeploy timer). They appear at:
+   - `https://pax-market.com/PAX_CREATION_GUIDE.md`
+   - `https://pax-market.com/PAX_USAGE_GUIDE.md`
+4. **praxis** (the runtime engine) keeps a vendored copy of `PAX_CREATION_GUIDE.md` at `praxis/docs/PAX_CREATION_GUIDE.md`. Its `sync-guide.yml` workflow runs hourly to pull the latest from this repo's release.
+
+## Why this lives here
+
+The creation guide is the authoring contract for pack contributors. Contributors interact with `pax-market`, not with the runtime engine. Keeping the guide with the registry that consumes it (and not with the engine that processes it) reduces operational friction — see migration tracker JELambert/pax-market#72.
+
+## Don't
+
+- Don't remove or rename the `<!-- PAX_SCHEMA_START -->`, `<!-- PAX_SCHEMA_END -->`, `<!-- PAX_FIELDS_START -->`, or `<!-- PAX_FIELDS_END -->` markers. Praxis parses them at import time.
+- Don't edit the vendored copy in praxis directly — the sync workflow will revert it.


### PR DESCRIPTION
## Summary
Phase 1 of the PAX-guide migration — see umbrella tracker #72.

- Adds \`docs/PAX_CREATION_GUIDE.md\` and \`docs/PAX_USAGE_GUIDE.md\` (byte-identical copies from their current sources).
- Adds \`docs/README.md\` explaining the canonical-source convention.
- Edits \`.github/workflows/publish-artifacts.yml\`:
  - \`docs/**\` added to path filter (guide edits trigger releases).
  - New "Verify guide markers" step (loud failure on missing markers).
  - Release \`latest\` now includes both guides as additional assets.

## Why
Pack contributors interact with pax-market, not with the runtime engine. Keeping the authoring contract here (instead of in praxis) reduces operational friction. See #72 for full context and the deferred Option C decision.

## Backwards compatibility
- Praxis is **untouched** in this PR. Its \`pax_schema.py\` still reads from \`praxis/docs/PAX_CREATION_GUIDE.md\` (vendored copy stays in place; sync-guide.yml in Phase 3 will refresh it from this repo's release).
- pax-website's \`fetch-artifacts.sh\` still reads from \`/opt/praxis/docs/\` until Phase 2 lands.
- This PR is fully additive. Rollback = revert.

## Verification after merge
- \`gh release view latest --repo JELambert/pax-market --json assets --jq '[.assets[].name] | sort'\` should show 6 assets including both .md files.
- \`curl -fsSL https://github.com/JELambert/pax-market/releases/download/latest/PAX_CREATION_GUIDE.md | grep -c PAX_SCHEMA_START\` → \`1\`.
- \`diff <(curl -fsSL …pax-market…/PAX_CREATION_GUIDE.md) /Volumes/.../praxis/docs/PAX_CREATION_GUIDE.md\` → empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)