### PR TITLE
docs: refresh README + CLAUDE.md after guide-migration (Phase 5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,58 +1,89 @@
 # PAX Registry
 
 ## What This Is
-Git-based registry for PAX (Portable Analytical eXpertise) packages. This repo IS the source of truth for published packs — no database dependency. The website frontend lives in the separate `pax-website` repo.
+Git-based registry for PAX (Portable Analytical eXpertise) packages. This repo IS the source of truth for published packs AND the canonical home of the PAX authoring/usage guides — no database dependency. The website frontend lives in the separate `pax-website` repo; the runtime engine lives in `praxis` (which vendors a copy of the creation guide from here).
 
 **Browse at [pax-market.com](https://pax-market.com)**
 
-## Architecture (Two-Repo Split)
+## Architecture (Three-Repo Split)
 ```
-This repo (pax-market) = REGISTRY
-  pax/<name>/                    ← Pack source directories (66+ packs)
+This repo (pax-market) = REGISTRY + canonical docs
+  pax/<name>/                    ← Pack source directories (currently 14 packs)
+  docs/PAX_CREATION_GUIDE.md     ← Canonical authoring spec (parsed by praxis at import time)
+  docs/PAX_USAGE_GUIDE.md        ← Canonical usage guide (LLM-feedable)
   scripts/generate-registry.py   ← Builds artifacts from pax/
   .github/workflows/
-    validate-pack.yml            ← PR validation
+    validate-pack.yml            ← PR validation (schema, JSON, etc.)
     auto-merge-pack.yml          ← Auto-merge non-community PRs
-    publish-artifacts.yml        ← Creates GitHub Release on push to main
+    stamp-published-by.yml       ← Auto-stamp PR submitter login on community manifests
+    publish-artifacts.yml        ← Creates GitHub Release on push to main (registry + guides)
+    deploy-marketplace.yml       ← Build verification
 
 pax-website repo = FRONTEND
-  Fetches artifacts from this repo's GitHub Releases
+  Fetches release artifacts (registry JSON + both guides) from this repo
   Generates Hugo pages from full-catalog.json
-  Deploys to pax-market.com
+  Deploys to pax-market.com via homelab CT 105 (5-min poll)
+
+praxis repo = RUNTIME ENGINE
+  Vendors docs/PAX_CREATION_GUIDE.md → praxis/docs/PAX_CREATION_GUIDE.md
+  pax_schema.py parses the vendored copy at import time (regex on PAX_SCHEMA_START / PAX_FIELDS_START blocks)
+  .github/workflows/sync-guide.yml refreshes the vendored copy hourly from this repo's `latest` release
 ```
 
 ## Key Commands
 - `python3 scripts/generate-registry.py` — Generate artifacts to `dist/`
 - Artifacts: `dist/registry.json`, `dist/constructs.json`, `dist/full-catalog.json`, `dist/pax/*.pax.tar.gz`
+- Release assets (from `publish-artifacts.yml`): the four `dist/` files above + `dist/pax-archives.tar` + `docs/PAX_CREATION_GUIDE.md` + `docs/PAX_USAGE_GUIDE.md`
 
 ## How Packs Are Published
 1. Contributor submits pack via [submit.pax-market.com](https://submit.pax-market.com) or opens a PR
 2. `validate-pack.yml` validates schema on the PR
-3. Non-community PRs auto-merge; community PRs require manual review
-4. On merge to `main` → `publish-artifacts.yml` creates/updates GitHub Release (`latest` tag)
-5. pax-website detects new release → fetches artifacts → rebuilds → deploys to pax-market.com
+3. `stamp-published-by.yml` injects `published_by: <PR-author-login>` into manifests missing the field (community attribution)
+4. Non-community PRs auto-merge; community PRs require manual review
+5. On merge to `main` → `publish-artifacts.yml` creates/updates GitHub Release (`latest` tag) with all 6 assets
+6. pax-website detects new release → fetches artifacts → rebuilds → deploys to pax-market.com
+
+## How Guide Edits Propagate
+1. Edit `docs/PAX_CREATION_GUIDE.md` or `docs/PAX_USAGE_GUIDE.md` in a PR.
+2. `publish-artifacts.yml`'s "Verify guide markers" step asserts `<!-- PAX_SCHEMA_START -->` and `<!-- PAX_FIELDS_START -->` are intact (loud failure otherwise).
+3. On merge → fresh release with both guides as assets.
+4. **pax-website** fetches the release → guides served at `https://pax-market.com/PAX_CREATION_GUIDE.md` and `.../PAX_USAGE_GUIDE.md` within 5 min.
+5. **praxis** `sync-guide.yml` runs hourly → pulls `PAX_CREATION_GUIDE.md` from this repo's release → commits as `praxis-sync-bot` to praxis main → next praxis release picks up the new schema.
 
 ## CI Workflows
 - **validate-pack.yml** — Runs on PRs with `pax/**` changes. Checks required fields, valid enums, JSON validity.
-- **auto-merge-pack.yml** — Enables squash merge on valid pack PRs. Skips PRs labeled `community`.
-- **publish-artifacts.yml** — On push to main, runs `generate-registry.py` and creates GitHub Release with all artifacts.
+- **stamp-published-by.yml** — Runs on PRs with `pax/**/pax.yaml` changes. Auto-stamps `published_by: <PR-author-login>` if not declared.
+- **auto-merge-pack.yml** — Enables squash merge on valid pack PRs. Skips PRs labeled `community` (those need manual review).
+- **publish-artifacts.yml** — On push to main affecting `pax/**`, `scripts/generate-registry.py`, or `docs/**`, runs `generate-registry.py` and creates GitHub Release with all artifacts (4 registry + 2 guides).
+- **deploy-marketplace.yml** — Build verification.
 
 ## Project Structure
 ```
-pax/                         66+ pack directories (source of truth)
+pax/                         14 pack directories (source of truth for packs)
+docs/                        Canonical PAX guides
+  PAX_CREATION_GUIDE.md      Authoring spec — praxis parses this at import time
+  PAX_USAGE_GUIDE.md         LLM-feedable usage guide
+  README.md                  How edits propagate to website + praxis
 scripts/
   generate-registry.py       Builds dist/ artifacts from pax/
-  generate-from-git.py       LEGACY (monorepo generator, being removed)
 .github/workflows/
   validate-pack.yml          PR validation
+  stamp-published-by.yml     Auto-attribution
   auto-merge-pack.yml        Auto-merge for non-community PRs
-  publish-artifacts.yml      Artifact publishing on merge
+  publish-artifacts.yml      Artifact + guide release on merge
+  deploy-marketplace.yml     Build verify
 dist/                        .gitignored — build output
 ```
 
 ## Pack Schema
 - Required manifest fields: `name`, `version`, `description`, `pax_type`, `schema_version`
 - Valid `pax_type`: paper, topic, field, engine, enterprise
-- Valid `schema_version`: "1.0", "2.0"
+- Valid `schema_version`: "1.0", "2.0", "3.0"
 - Knowledge files: `constructs.json`, `findings.json`, `sources.json`, `domain.json`
 - Optional: `propositions.json`, `construct_relationships.json`, `playbooks/*.yaml`
+- v3 additions: `canonical_constructs.json`, `construct_relations.json` (canonical-construct backbone); `unit_of_analysis`, `scope_conditions`, `sample_n` on findings; `canonical_id`, `operationalization_id`, `coding_rule` on constructs
+
+## Don't
+- Don't remove or rename the `<!-- PAX_SCHEMA_START -->`, `<!-- PAX_SCHEMA_END -->`, `<!-- PAX_FIELDS_START -->`, or `<!-- PAX_FIELDS_END -->` markers in `docs/PAX_CREATION_GUIDE.md`. Praxis parses them at import time; corruption breaks every consumer.
+- Don't edit the praxis vendored copy (`praxis/docs/PAX_CREATION_GUIDE.md`) directly — it'll be overwritten on the next sync.
+- Don't hardcode schema version lists in new code — they belong in the SCHEMA_START block.

--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ Anyone can submit a pack.
 ### Creation Guide
 See the full [PAX Creation Guide](https://pax-market.com/guide/) for how to build a pack from scratch. You can also [download the spec](https://pax-market.com/PAX_CREATION_GUIDE.md) and feed it to any LLM along with your source material to generate a valid pack.
 
+The canonical source of both the [creation guide](docs/PAX_CREATION_GUIDE.md) and the [usage guide](docs/PAX_USAGE_GUIDE.md) lives in this repo under `docs/`. Edits there propagate to the website (via release artifacts) and to praxis (via its sync workflow). See `docs/README.md` for details.
+
 ## Validation
 
 PRs touching `pax/**` are validated automatically:
 
 - Required manifest fields: `name`, `version`, `description`, `pax_type`, `schema_version`
 - Valid `pax_type`: paper, topic, field, engine, enterprise
-- Valid `schema_version`: 1.0, 2.0
+- Valid `schema_version`: 1.0, 2.0, 3.0
 - All JSON files must be valid
 - At least one construct recommended
 
@@ -66,10 +68,11 @@ PRs touching `pax/**` are validated automatically:
 ```
 Pack added to pax/ → PR validated by CI → merged → publish-artifacts.yml runs
   → GitHub Release created with registry.json + full-catalog.json + tar.gz archives
+    + PAX_CREATION_GUIDE.md + PAX_USAGE_GUIDE.md
   → pax-market.com fetches release → rebuilds → pack appears on the site
 ```
 
-This repo is the **registry** — it contains pack data only. The website frontend lives in a [separate repo](https://github.com/JELambert/pax-website).
+This repo is the **registry** — it contains pack data and the canonical authoring guides. The website frontend lives in a [separate repo](https://github.com/JELambert/pax-website). Praxis (the runtime engine) keeps a vendored copy of the creation guide synced from this repo's releases.
 
 ## Using Packs
 


### PR DESCRIPTION
Phase 5 of PAX-guide migration (#72). Brings repo-internal docs into sync with reality:

- `README.md`: Creation Guide section notes canonical `docs/` location; schema_version list adds 3.0; How It Works mentions guides as release assets.
- `CLAUDE.md`: full refresh — three-repo split (was two); current pack count; current workflow list; new 'How Guide Edits Propagate' section; v3 schema additions; marker-preservation warnings.

Companion issues filed in praxis and pax-website for their own README/CONTRIBUTING/etc updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)