### PR TITLE
fix: install pyyaml in workflow-lint runner

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install pyyaml
+        run: pip install pyyaml
+
       - name: "Validate every workflow file parses + has on/jobs block"
         run: |
           set -euo pipefail


### PR DESCRIPTION
Same fix as JELambert/praxis on its #378 branch — GitHub-hosted runners don't ship pyyaml by default.