### PR TITLE
ci: validate-pack catches dangling FK refs in findings (#81)

### DIFF
--- a/.github/workflows/validate-pack.yml
+++ b/.github/workflows/validate-pack.yml
@@ -103,6 +103,67 @@ jobs:
                   except Exception:
                       pass
 
+              # Cross-reference integrity: findings must reference IDs that
+              # actually exist. Catches the JELambert/pax-market#81 class of
+              # bug (pmsc-market-for-force shipped with 5 undefined sub-domains
+              # and 3 undefined constructs, breaking praxis_install_pax).
+              if knowledge_dir.is_dir():
+                  def _safe_load(p):
+                      try:
+                          with open(p) as f:
+                              return json.load(f)
+                      except Exception:
+                          return None
+
+                  findings = _safe_load(knowledge_dir / 'findings.json') or []
+                  if not isinstance(findings, list):
+                      findings = []
+
+                  if findings:
+                      # Collect known IDs from each entity file. domain.json may
+                      # be a single object OR a list — handle both.
+                      def _ids(data, key='id'):
+                          if data is None: return set()
+                          if isinstance(data, dict): data = [data]
+                          return {x.get(key) for x in data if isinstance(x, dict) and x.get(key)}
+
+                      known_constructs = _ids(_safe_load(knowledge_dir / 'constructs.json'))
+                      known_domains    = _ids(_safe_load(knowledge_dir / 'domain.json')) | _ids(_safe_load(knowledge_dir / 'domains.json'))
+                      known_sources    = _ids(_safe_load(knowledge_dir / 'sources.json'))
+
+                      missing_constructs = set()
+                      missing_domains    = set()
+                      missing_sources    = set()
+
+                      for fnd in findings:
+                          if not isinstance(fnd, dict):
+                              continue
+                          # construct_ids may be list or comma-separated string
+                          cs = fnd.get('construct_ids', [])
+                          if isinstance(cs, str):
+                              cs = [s.strip() for s in cs.split(',') if s.strip()]
+                          for cid in cs:
+                              if cid and cid not in known_constructs:
+                                  missing_constructs.add(cid)
+                          # domain references
+                          d = fnd.get('domain_id')
+                          if d and d not in known_domains:
+                              missing_domains.add(d)
+                          for sd in (fnd.get('sub_domain_ids') or []):
+                              if sd and sd not in known_domains:
+                                  missing_domains.add(sd)
+                          # source — either source_id or embedded {id: ...}
+                          src = fnd.get('source_id') or (fnd.get('source') or {}).get('id') if isinstance(fnd.get('source'), dict) else fnd.get('source_id')
+                          if src and known_sources and src not in known_sources:
+                              missing_sources.add(src)
+
+                      if missing_constructs:
+                          errors.append(f'{pack_dir.name}: findings reference {len(missing_constructs)} undefined construct_id(s): {sorted(missing_constructs)}')
+                      if missing_domains:
+                          errors.append(f'{pack_dir.name}: findings reference {len(missing_domains)} undefined domain/sub_domain id(s) — add them to domain.json or remove the references: {sorted(missing_domains)}')
+                      if missing_sources:
+                          errors.append(f'{pack_dir.name}: findings reference {len(missing_sources)} undefined source_id(s): {sorted(missing_sources)}')
+
           # Report
           if warnings:
               print('Warnings:')


### PR DESCRIPTION
## Summary
Extends `validate-pack.yml` so every `construct_id`, `domain_id`, `sub_domain_id`, and `source_id` referenced by findings must resolve to an entity defined in the corresponding knowledge file.

## Why
[#81](https://github.com/JELambert/pax-market/issues/81) found `pmsc-market-for-force` shipped with 5 undefined sub-domains and 3 undefined constructs. `praxis_install_pax` fails on FK constraint at install time. The export pipeline that produced this pack is broken on the praxis side (tracked separately in JELambert/praxis#379), but pax-market's CI should refuse to publish a pack with the same bug going forward.

## Scope
Validates only packs **changed in the PR** — preserves existing behavior. Existing broken packs (pmsc and any others not yet diagnosed) stay grandfathered until someone touches them, which avoids retroactively blocking unrelated PRs.

## Verified locally
```
$ python3 <validation logic> against pax/pmsc-market-for-force/
missing constructs: ['pmsc_industry_size', 'pmsc_symbolic_power', 'wagner_group_model']
missing domains: ['pmsc_china_bri', 'pmsc_conflict_consequences', 'pmsc_data_measurement', 'pmsc_regulation', 'pmsc_typology']
missing sources: []
```
Matches #81 exactly.

## Domain shape
Handles both `domain.json` shapes seen in the registry:
- Single object (pmsc style): `{id: 'foo', ...}`
- List (FL2003 style): `[{id: 'foo'}, ...]`
Also picks up `domains.json` (plural) if present.

## Does not fix the existing pmsc data
That remains open in #81 — re-export from praxis once #379 is addressed, or directly repair the pack here. This PR just stops the bleeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)