### PR TITLE
feat: extract validate_pax.py — manifest-driven PR-time validator (#85)

### DIFF
--- a/.github/workflows/validate-pack.yml
+++ b/.github/workflows/validate-pack.yml
@@ -21,174 +21,32 @@ jobs:
       - name: Install dependencies
         run: pip install pyyaml
 
-      - name: Validate packs in PR
+      - name: Validate changed packs
         run: |
-          python3 -c "
-          import json, sys, os, yaml, subprocess
-          from pathlib import Path
-
-          REQUIRED_MANIFEST = ['name', 'version', 'description', 'pax_type', 'schema_version']
-          VALID_TYPES = ['paper', 'topic', 'field', 'engine', 'enterprise']
-          VALID_SCHEMA_VERSIONS = ['1.0', '2.0', '3.0']
-          errors = []
-          warnings = []
-
-          # Find only pack directories changed in this PR
-          result = subprocess.run(
-              ['git', 'diff', '--name-only', 'origin/main...HEAD'],
-              capture_output=True, text=True
+          set -euo pipefail
+          # Find pack directories changed in this PR.
+          changed_packs=$(
+            git diff --name-only origin/main...HEAD -- 'pax/' \
+              | awk -F/ 'NF>=2 && $1=="pax" {print $2}' \
+              | sort -u
           )
-          changed_files = result.stdout.strip().splitlines()
-          changed_packs = set()
-          for f in changed_files:
-              parts = Path(f).parts
-              if len(parts) >= 2 and parts[0] == 'pax':
-                  changed_packs.add(parts[1])
-
-          if not changed_packs:
-              print('No pax/ changes in this PR — skipping validation')
-              sys.exit(0)
-
-          print(f'Validating {len(changed_packs)} changed pack(s): {sorted(changed_packs)}')
-
-          for pack_name in sorted(changed_packs):
-              pack_dir = Path('pax') / pack_name
-              if not pack_dir.is_dir():
-                  continue  # deleted pack, skip
-              manifest_path = pack_dir / 'pax.yaml'
-              if not manifest_path.exists():
-                  errors.append(f'{pack_dir.name}: missing pax.yaml')
-                  continue
-
-              # Parse manifest
-              try:
-                  with open(manifest_path) as f:
-                      manifest = yaml.safe_load(f)
-              except Exception as e:
-                  errors.append(f'{pack_dir.name}: invalid pax.yaml: {e}')
-                  continue
-
-              # Required fields
-              for field in REQUIRED_MANIFEST:
-                  if not manifest.get(field):
-                      errors.append(f'{pack_dir.name}: missing required field: {field}')
-
-              # Valid pax_type
-              if manifest.get('pax_type') and manifest['pax_type'] not in VALID_TYPES:
-                  errors.append(f'{pack_dir.name}: invalid pax_type: {manifest[\"pax_type\"]}')
-
-              # Valid schema_version
-              sv = str(manifest.get('schema_version', ''))
-              if sv and sv not in VALID_SCHEMA_VERSIONS:
-                  errors.append(f'{pack_dir.name}: unrecognized schema_version: {sv}')
-
-              # Knowledge files valid JSON
-              knowledge_dir = pack_dir / 'knowledge'
-              if knowledge_dir.is_dir():
-                  for json_file in knowledge_dir.glob('*.json'):
-                      try:
-                          with open(json_file) as f:
-                              json.load(f)
-                      except json.JSONDecodeError as e:
-                          errors.append(f'{pack_dir.name}/knowledge/{json_file.name}: invalid JSON: {e}')
-
-              # Quality check: at least 1 construct
-              constructs_file = knowledge_dir / 'constructs.json' if knowledge_dir.is_dir() else None
-              if constructs_file and constructs_file.exists():
-                  try:
-                      with open(constructs_file) as f:
-                          constructs = json.load(f)
-                      if isinstance(constructs, list) and len(constructs) == 0:
-                          warnings.append(f'{pack_dir.name}: no constructs defined')
-                  except Exception:
-                      pass
-
-              # Cross-reference integrity: findings must reference IDs that
-              # actually exist. Catches the JELambert/pax-market#81 class of
-              # bug (pmsc-market-for-force shipped with 5 undefined sub-domains
-              # and 3 undefined constructs, breaking praxis_install_pax).
-              if knowledge_dir.is_dir():
-                  def _safe_load(p):
-                      try:
-                          with open(p) as f:
-                              return json.load(f)
-                      except Exception:
-                          return None
-
-                  findings = _safe_load(knowledge_dir / 'findings.json') or []
-                  if not isinstance(findings, list):
-                      findings = []
-
-                  if findings:
-                      # Collect known IDs from each entity file. domain.json may
-                      # be a single object OR a list — handle both.
-                      def _ids(data, key='id'):
-                          if data is None: return set()
-                          if isinstance(data, dict): data = [data]
-                          return {x.get(key) for x in data if isinstance(x, dict) and x.get(key)}
-
-                      known_constructs = _ids(_safe_load(knowledge_dir / 'constructs.json'))
-                      known_domains    = _ids(_safe_load(knowledge_dir / 'domain.json')) | _ids(_safe_load(knowledge_dir / 'domains.json'))
-                      known_sources    = _ids(_safe_load(knowledge_dir / 'sources.json'))
-
-                      missing_constructs = set()
-                      missing_domains    = set()
-                      missing_sources    = set()
-                      string_shape_construct_ids = 0
-                      string_shape_covariates    = 0
-
-                      for fnd in findings:
-                          if not isinstance(fnd, dict):
-                              continue
-                          # construct_ids must be a JSON array per PAX_CREATION_GUIDE.md.
-                          # Older exporters wrote comma-separated strings; praxis v2's
-                          # loader tolerates that defensively (af58dd1) but the PAX
-                          # itself should ship the spec shape. Tracked: #84.
-                          cs = fnd.get('construct_ids', [])
-                          if isinstance(cs, str):
-                              string_shape_construct_ids += 1
-                              cs = [s.strip() for s in cs.split(',') if s.strip()]
-                          # Same shape requirement on covariates_controlled.
-                          cv = fnd.get('covariates_controlled')
-                          if isinstance(cv, str):
-                              string_shape_covariates += 1
-                          for cid in cs:
-                              if cid and cid not in known_constructs:
-                                  missing_constructs.add(cid)
-                          # domain references
-                          d = fnd.get('domain_id')
-                          if d and d not in known_domains:
-                              missing_domains.add(d)
-                          for sd in (fnd.get('sub_domain_ids') or []):
-                              if sd and sd not in known_domains:
-                                  missing_domains.add(sd)
-                          # source — either source_id or embedded {id: ...}
-                          src = fnd.get('source_id') or (fnd.get('source') or {}).get('id') if isinstance(fnd.get('source'), dict) else fnd.get('source_id')
-                          if src and known_sources and src not in known_sources:
-                              missing_sources.add(src)
-
-                      if missing_constructs:
-                          errors.append(f'{pack_dir.name}: findings reference {len(missing_constructs)} undefined construct_id(s): {sorted(missing_constructs)}')
-                      if missing_domains:
-                          errors.append(f'{pack_dir.name}: findings reference {len(missing_domains)} undefined domain/sub_domain id(s) — add them to domain.json or remove the references: {sorted(missing_domains)}')
-                      if missing_sources:
-                          errors.append(f'{pack_dir.name}: findings reference {len(missing_sources)} undefined source_id(s): {sorted(missing_sources)}')
-                      if string_shape_construct_ids:
-                          errors.append(f'{pack_dir.name}: {string_shape_construct_ids} findings have construct_ids as a string; PAX_CREATION_GUIDE.md requires a JSON array. Convert \"a,b,c\" → [\"a\",\"b\",\"c\"].')
-                      if string_shape_covariates:
-                          errors.append(f'{pack_dir.name}: {string_shape_covariates} findings have covariates_controlled as a string; PAX_CREATION_GUIDE.md requires a JSON array.')
-
-          # Report
-          if warnings:
-              print('Warnings:')
-              for w in warnings:
-                  print(f'  ⚠ {w}')
-
-          if errors:
-              print('Errors:')
-              for e in errors:
-                  print(f'  ✗ {e}')
-              sys.exit(1)
-          else:
-              print(f'✓ All packs valid')
-          "
+          if [ -z "$changed_packs" ]; then
+            echo "No pax/ changes in this PR — skipping validation."
+            exit 0
+          fi
+          echo "Validating $(echo "$changed_packs" | wc -l | tr -d ' ') changed pack(s):"
+          echo "$changed_packs" | sed 's/^/  /'
+          fail=0
+          for pack in $changed_packs; do
+            dir="pax/$pack"
+            if [ ! -d "$dir" ]; then
+              echo "  (deleted: $pack — skipping)"
+              continue
+            fi
+            python3 scripts/validate_pax.py "$dir" || fail=1
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo
+            echo "::error::One or more packs failed validation. See log above."
+            exit 1
+          fi

--- a/scripts/validate_pax.py
+++ b/scripts/validate_pax.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""validate_pax.py — PR-time PAX structural validator.
+
+Reads docs/PAX_CREATION_GUIDE.md as the contract:
+  - <!-- PAX_SCHEMA_START --> ... <!-- PAX_SCHEMA_END -->   controlled vocabularies
+  - <!-- PAX_FIELDS_START --> ... <!-- PAX_FIELDS_END -->   per-entity field manifest
+
+Validates a single PAX directory against that contract. Designed to run
+both locally (developer pre-flight) and in CI (validate-pack.yml).
+
+Usage:
+    python3 scripts/validate_pax.py pax/<pack-name>
+    python3 scripts/validate_pax.py pax/<pack-name> --guide docs/PAX_CREATION_GUIDE.md
+
+Exit codes:
+    0 — all checks passed
+    1 — validation errors (printed to stdout grouped by check)
+    2 — usage error (bad args, missing files)
+
+Background: pax-market#85 (the issue this implements).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# YAML is needed for pax.yaml + the FIELDS_START block.
+try:
+    import yaml
+except ImportError:
+    print("ERROR: pyyaml is required. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_GUIDE = REPO_ROOT / "docs" / "PAX_CREATION_GUIDE.md"
+
+VALID_PAX_TYPES = ("paper", "topic", "field", "engine", "enterprise")
+VALID_SCHEMA_VERSIONS = ("1.0", "2.0", "3.0")
+
+# Entities whose JSON file is REQUIRED if the pack has any findings.
+# (Other entities — propositions, canonical_constructs, etc. — are optional.)
+REQUIRED_KNOWLEDGE_FILES = ("constructs.json", "sources.json", "findings.json")
+
+
+# ---------------------------------------------------------------------------
+# Guide parsers
+# ---------------------------------------------------------------------------
+
+def parse_schema_block(guide_text: str) -> dict[str, list[str]]:
+    """Extract enum vocabularies from <!-- PAX_SCHEMA_START -->..<!-- PAX_SCHEMA_END -->.
+    Lines look like: **field_name values:** v1, v2, v3"""
+    m = re.search(r"<!-- PAX_SCHEMA_START.*?-->(.+?)<!-- PAX_SCHEMA_END", guide_text, re.DOTALL)
+    if not m:
+        raise RuntimeError("guide is missing PAX_SCHEMA_START/END markers")
+    block = m.group(1)
+    enums: dict[str, list[str]] = {}
+    for line in block.splitlines():
+        em = re.match(r"\*\*(\w+) values:\*\*\s*(.+)", line.strip())
+        if em:
+            name = em.group(1)
+            values = [v.strip() for v in em.group(2).split(",") if v.strip()]
+            enums[name] = values
+    if not enums:
+        raise RuntimeError("PAX_SCHEMA block parsed but contains no enums")
+    return enums
+
+
+def parse_fields_block(guide_text: str) -> dict[str, dict]:
+    """Extract per-entity field manifest from <!-- PAX_FIELDS_START --> ... <!-- PAX_FIELDS_END -->.
+    The block contains a yaml fenced section under `entities:`."""
+    m = re.search(r"<!-- PAX_FIELDS_START.*?-->(.+?)<!-- PAX_FIELDS_END", guide_text, re.DOTALL)
+    if not m:
+        raise RuntimeError("guide is missing PAX_FIELDS_START/END markers")
+    block = m.group(1)
+    ym = re.search(r"```yaml\s*\n(.+?)```", block, re.DOTALL)
+    if not ym:
+        raise RuntimeError("PAX_FIELDS block has no ```yaml fence")
+    parsed = yaml.safe_load(ym.group(1))
+    return parsed.get("entities") or {}
+
+
+def field_spec_name(spec: Any) -> str:
+    """Field-manifest entries are either bare strings or {name, type, enum} dicts."""
+    if isinstance(spec, dict):
+        return spec.get("name", "")
+    return str(spec)
+
+
+def field_spec_type(spec: Any) -> tuple[str, str | None]:
+    """Returns (type, enum-vocab-name) for a manifest field spec, or ('', None)."""
+    if isinstance(spec, dict):
+        return spec.get("type", ""), spec.get("enum")
+    return "", None
+
+
+# ---------------------------------------------------------------------------
+# Pack helpers
+# ---------------------------------------------------------------------------
+
+def safe_load_json(p: Path) -> Any:
+    try:
+        with p.open() as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except json.JSONDecodeError as e:
+        return e
+
+
+def normalize_to_list(data: Any) -> list:
+    if data is None:
+        return []
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        return [data]
+    return []
+
+
+def collect_ids(items: list, key: str = "id") -> set[str]:
+    return {x.get(key) for x in items if isinstance(x, dict) and x.get(key)}
+
+
+# ---------------------------------------------------------------------------
+# Validation passes
+# ---------------------------------------------------------------------------
+
+class Validator:
+    def __init__(self, pack_dir: Path, enums: dict[str, list[str]], fields: dict[str, dict]):
+        self.pack_dir = pack_dir
+        self.pack_name = pack_dir.name
+        self.enums = enums
+        self.fields = fields
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+
+    def err(self, msg: str) -> None:
+        self.errors.append(msg)
+
+    def warn(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    # -------------------------------------------------------------------
+    # Pass 1: file presence
+    # -------------------------------------------------------------------
+
+    def check_files(self) -> None:
+        if not (self.pack_dir / "pax.yaml").exists():
+            self.err("missing pax.yaml")
+        knowledge = self.pack_dir / "knowledge"
+        if not knowledge.is_dir():
+            self.err("missing knowledge/ directory")
+            return
+        for fname in REQUIRED_KNOWLEDGE_FILES:
+            if not (knowledge / fname).exists():
+                self.err(f"missing knowledge/{fname}")
+        # domain.json or domains.json
+        if not (knowledge / "domain.json").exists() and not (knowledge / "domains.json").exists():
+            self.err("missing knowledge/domain.json (or domains.json)")
+
+    # -------------------------------------------------------------------
+    # Pass 2: manifest
+    # -------------------------------------------------------------------
+
+    def check_manifest(self) -> dict | None:
+        path = self.pack_dir / "pax.yaml"
+        if not path.exists():
+            return None
+        try:
+            with path.open() as f:
+                manifest = yaml.safe_load(f) or {}
+        except yaml.YAMLError as e:
+            self.err(f"pax.yaml: invalid YAML: {e}")
+            return None
+        if not isinstance(manifest, dict):
+            self.err(f"pax.yaml: top-level must be a mapping, got {type(manifest).__name__}")
+            return None
+
+        # Required fields per PAX_FIELDS manifest (with sensible fallback).
+        spec = self.fields.get("pax_yaml", {}) or {}
+        required = spec.get("required") or list(REQUIRED_PAX_YAML_FIELDS)
+        for field in required:
+            name = field_spec_name(field)
+            if name and not manifest.get(name):
+                self.err(f"pax.yaml: missing required field '{name}'")
+
+        # Name conventions
+        name = manifest.get("name", "")
+        if name and not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", name):
+            self.err(f"pax.yaml: name '{name}' must be lower-kebab-case")
+        if name and name != self.pack_name:
+            self.err(f"pax.yaml: name '{name}' does not match directory name '{self.pack_name}'")
+
+        # version: semver-ish (M.m.p with optional -prerelease)
+        version = str(manifest.get("version", ""))
+        if version and not re.fullmatch(r"\d+\.\d+\.\d+(-[\w.-]+)?", version):
+            self.err(f"pax.yaml: version '{version}' is not a valid semver")
+
+        # schema_version: enum
+        sv = str(manifest.get("schema_version", ""))
+        if sv and sv not in VALID_SCHEMA_VERSIONS:
+            self.err(f"pax.yaml: schema_version '{sv}' not in {VALID_SCHEMA_VERSIONS}")
+
+        # pax_type: enum
+        pt = manifest.get("pax_type")
+        if pt and pt not in VALID_PAX_TYPES:
+            self.err(f"pax.yaml: pax_type '{pt}' not in {VALID_PAX_TYPES}")
+
+        return manifest
+
+    # -------------------------------------------------------------------
+    # Pass 3: knowledge JSON syntax
+    # -------------------------------------------------------------------
+
+    def check_knowledge_json(self) -> dict[str, Any]:
+        knowledge = self.pack_dir / "knowledge"
+        loaded: dict[str, Any] = {}
+        if not knowledge.is_dir():
+            return loaded
+        for json_path in knowledge.glob("*.json"):
+            data = safe_load_json(json_path)
+            if isinstance(data, json.JSONDecodeError):
+                self.err(f"knowledge/{json_path.name}: invalid JSON: {data}")
+            else:
+                loaded[json_path.name] = data
+        return loaded
+
+    # -------------------------------------------------------------------
+    # Pass 4: per-entity required fields + types + enums
+    # -------------------------------------------------------------------
+
+    def check_entity_fields(self, knowledge: dict[str, Any]) -> None:
+        # Map filename → entity-name in PAX_FIELDS manifest.
+        file_to_entity = {
+            "domain.json":                      "domain",
+            "domains.json":                     "domain",
+            "sources.json":                     "source",
+            "constructs.json":                  "construct",
+            "findings.json":                    "finding",
+            "propositions.json":                "proposition",
+            "construct_relationships.json":     "construct_relationship",
+            "construct_relations.json":         "construct_relation",
+            "canonical_constructs.json":        "canonical_construct",
+        }
+        for fname, entity in file_to_entity.items():
+            if fname not in knowledge:
+                continue
+            spec = self.fields.get(entity)
+            if not spec:
+                continue
+            items = normalize_to_list(knowledge[fname])
+            for idx, item in enumerate(items):
+                if not isinstance(item, dict):
+                    self.err(f"{fname}[{idx}]: must be an object, got {type(item).__name__}")
+                    continue
+                self._check_required(item, spec.get("required") or [], fname, idx)
+                self._check_typed_fields(item, spec.get("recommended") or [], fname, idx, severity="recommended")
+                self._check_typed_fields(item, spec.get("optional") or [], fname, idx, severity="optional")
+
+    def _check_required(self, item: dict, required: list, fname: str, idx: int) -> None:
+        for field in required:
+            name = field_spec_name(field)
+            type_, enum_ref = field_spec_type(field)
+            if name and item.get(name) in (None, "", []):
+                self.err(f"{fname}[{idx}]: missing required field '{name}'")
+                continue
+            self._check_one_field(item, name, type_, enum_ref, fname, idx)
+
+    def _check_typed_fields(self, item: dict, fields: list, fname: str, idx: int, severity: str) -> None:
+        for field in fields:
+            name = field_spec_name(field)
+            type_, enum_ref = field_spec_type(field)
+            if not name or item.get(name) is None:
+                continue
+            self._check_one_field(item, name, type_, enum_ref, fname, idx)
+
+    def _check_one_field(self, item: dict, name: str, type_: str, enum_ref: str | None, fname: str, idx: int) -> None:
+        v = item.get(name)
+        if v is None:
+            return
+        # Type checks (per PAX_FIELDS manifest)
+        if type_ == "list" and not isinstance(v, list):
+            self.err(f"{fname}[{idx}].{name}: must be a JSON array, got {type(v).__name__} ({v!r:.40s})")
+            return
+        if type_ == "integer" and not isinstance(v, int):
+            self.err(f"{fname}[{idx}].{name}: must be an integer, got {type(v).__name__}")
+            return
+        if type_ == "number" and not isinstance(v, (int, float)):
+            self.err(f"{fname}[{idx}].{name}: must be a number, got {type(v).__name__}")
+            return
+        if type_ == "text" and not isinstance(v, str):
+            self.err(f"{fname}[{idx}].{name}: must be a string, got {type(v).__name__}")
+            return
+        # Enum membership
+        if type_ == "enum" and enum_ref:
+            # PAX_FIELDS manifest references enum names like UNIT_OF_ANALYSIS;
+            # the SCHEMA block keys are lowercase like unit_of_analysis.
+            key = enum_ref.lower()
+            allowed = self.enums.get(key)
+            if allowed is None:
+                # Strip _VALUES, _TYPES suffixes that some entries use.
+                for suffix in ("_values", "_types"):
+                    if key.endswith(suffix):
+                        allowed = self.enums.get(key[: -len(suffix)])
+                        break
+            if allowed is not None and v not in allowed:
+                self.err(f"{fname}[{idx}].{name}: '{v}' not in allowed values {allowed}")
+
+    # -------------------------------------------------------------------
+    # Pass 4b: known list-typed fields whose PAX_FIELDS entry is a bare
+    # string in 'required' (no type info available). Hardcoded here.
+    # Catches the JELambert/pax-market#84 class of bug.
+    # -------------------------------------------------------------------
+
+    KNOWN_LIST_FIELDS = {
+        "finding": ["construct_ids", "sub_domain_ids", "covariates_controlled"],
+        "construct": ["aliases", "measures", "domain_ids"],
+        "proposition": [],
+    }
+
+    def check_known_list_shapes(self, knowledge: dict[str, Any]) -> None:
+        for fname, entity in (
+            ("findings.json",   "finding"),
+            ("constructs.json", "construct"),
+            ("propositions.json","proposition"),
+        ):
+            if fname not in knowledge:
+                continue
+            items = normalize_to_list(knowledge[fname])
+            for idx, item in enumerate(items):
+                if not isinstance(item, dict):
+                    continue
+                for field in self.KNOWN_LIST_FIELDS.get(entity, []):
+                    v = item.get(field)
+                    if v is None:
+                        continue
+                    if isinstance(v, str):
+                        self.err(f"{fname}[{idx}].{field}: must be a JSON array, got string. Convert \"a,b,c\" → [\"a\",\"b\",\"c\"].")
+
+    # -------------------------------------------------------------------
+    # Pass 5: cross-file FK references
+    # -------------------------------------------------------------------
+
+    def check_fk_refs(self, knowledge: dict[str, Any]) -> None:
+        findings = normalize_to_list(knowledge.get("findings.json"))
+        if not findings:
+            return
+        known_constructs = collect_ids(normalize_to_list(knowledge.get("constructs.json")))
+        known_domains = collect_ids(normalize_to_list(knowledge.get("domain.json"))) | collect_ids(normalize_to_list(knowledge.get("domains.json")))
+        known_sources = collect_ids(normalize_to_list(knowledge.get("sources.json")))
+
+        missing_constructs: set[str] = set()
+        missing_domains: set[str] = set()
+        missing_sources: set[str] = set()
+
+        for fnd in findings:
+            if not isinstance(fnd, dict):
+                continue
+            cs = fnd.get("construct_ids", [])
+            if isinstance(cs, str):
+                cs = [s.strip() for s in cs.split(",") if s.strip()]
+            for cid in cs:
+                if cid and cid not in known_constructs:
+                    missing_constructs.add(cid)
+            d = fnd.get("domain_id")
+            if d and d not in known_domains:
+                missing_domains.add(d)
+            for sd in (fnd.get("sub_domain_ids") or []):
+                if sd and sd not in known_domains:
+                    missing_domains.add(sd)
+            src = fnd.get("source_id")
+            if not src and isinstance(fnd.get("source"), dict):
+                src = fnd["source"].get("id")
+            if src and known_sources and src not in known_sources:
+                missing_sources.add(src)
+
+        if missing_constructs:
+            self.err(f"findings reference {len(missing_constructs)} undefined construct_id(s): {sorted(missing_constructs)}")
+        if missing_domains:
+            self.err(f"findings reference {len(missing_domains)} undefined domain/sub_domain id(s): {sorted(missing_domains)}")
+        if missing_sources:
+            self.err(f"findings reference {len(missing_sources)} undefined source_id(s): {sorted(missing_sources)}")
+
+    # -------------------------------------------------------------------
+    # Driver
+    # -------------------------------------------------------------------
+
+    def run(self) -> bool:
+        self.check_files()
+        self.check_manifest()
+        knowledge = self.check_knowledge_json()
+        self.check_entity_fields(knowledge)
+        self.check_known_list_shapes(knowledge)
+        self.check_fk_refs(knowledge)
+        return not self.errors
+
+
+# Fallback for pax.yaml required fields if the FIELDS manifest can't be parsed.
+REQUIRED_PAX_YAML_FIELDS = ("name", "version", "description", "schema_version", "pax_type")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a PAX directory against the canonical guide.")
+    parser.add_argument("pack_dir", type=Path, help="Path to a pax/<name>/ directory")
+    parser.add_argument("--guide", type=Path, default=DEFAULT_GUIDE,
+                        help="Path to PAX_CREATION_GUIDE.md (default: docs/PAX_CREATION_GUIDE.md)")
+    args = parser.parse_args()
+
+    pack_dir = args.pack_dir
+    if not pack_dir.is_dir():
+        print(f"ERROR: not a directory: {pack_dir}", file=sys.stderr)
+        return 2
+
+    guide_path = args.guide
+    if not guide_path.is_file():
+        print(f"ERROR: guide not found: {guide_path}", file=sys.stderr)
+        return 2
+
+    guide_text = guide_path.read_text()
+    try:
+        enums = parse_schema_block(guide_text)
+    except RuntimeError as e:
+        print(f"ERROR parsing guide PAX_SCHEMA: {e}", file=sys.stderr)
+        return 2
+    try:
+        fields = parse_fields_block(guide_text)
+    except RuntimeError as e:
+        print(f"ERROR parsing guide PAX_FIELDS: {e}", file=sys.stderr)
+        return 2
+
+    validator = Validator(pack_dir, enums, fields)
+    ok = validator.run()
+
+    if validator.warnings:
+        print(f"\n⚠ {pack_dir.name}: warnings:")
+        for w in validator.warnings:
+            print(f"  - {w}")
+    if validator.errors:
+        print(f"\n✗ {pack_dir.name}: {len(validator.errors)} error(s):")
+        for e in validator.errors:
+            print(f"  - {e}")
+        return 1
+    print(f"\n✓ {pack_dir.name}: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements step 1 of #85: standalone Python validator that reads `docs/PAX_CREATION_GUIDE.md` markers as the contract.

## What's new
- `scripts/validate_pax.py` — testable, scriptable, extensible. Parses both `PAX_SCHEMA_START` and `PAX_FIELDS_START` blocks; validates a PAX directory against the contract.
- `.github/workflows/validate-pack.yml` — slim wrapper that loops over PR-changed packs and invokes the script.

## Coverage matrix vs #85 spec
| Section | Status |
|---|---|
| 1. Required-file presence | ✅ pax.yaml + knowledge/{constructs,sources,findings,domain}.json |
| 2. Manifest validation | ✅ kebab-case name, semver version, schema_version/pax_type enums, all PAX_FIELDS-required fields |
| 3. Field-shape validation per entity | ✅ list/integer/number/text + enum membership against PAX_SCHEMA |
| 3a. Known-list shape (#84) | ✅ construct_ids, sub_domain_ids, covariates_controlled, aliases, measures, domain_ids |
| 4. Cross-file FK consistency | ✅ findings → constructs/domains/sub_domains/sources (proposition/canonical_id deferred to step 3) |
| 5. Round-trip parse check | ✅ json.load + yaml.safe_load |
| Structured PR comment | ⏳ deferred to step 4 (current behavior: print all errors, fail with non-zero exit) |

## Self-test
```
$ python3 scripts/validate_pax.py pax/smith-lambert-2026-beigesage
✓ smith-lambert-2026-beigesage: all checks passed

$ python3 scripts/validate_pax.py pax/batista-et-al-2025-brain-drain-gain
✓ batista-et-al-2025-brain-drain-gain: all checks passed

$ python3 scripts/validate_pax.py pax/pmsc-market-for-force
✗ pmsc-market-for-force: 13 error(s):
  - findings.json[28..35].construct_ids: must be a JSON array, got string
  - findings reference 3 undefined construct_id(s): [...]
  - findings reference 5 undefined domain/sub_domain id(s): [...]
```
Reproduces exactly what #81 + #84 documented.

## Existing data is grandfathered
The CI loop only validates *changed* packs in the PR. The 11 broken packs from #83 stay grandfathered until they're touched. New submissions and re-exports must pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)