### PR TITLE
fix: bayesian-methods pack passes validator (#83)

### DIFF
--- a/pax/bayesian-methods/knowledge/domain.json
+++ b/pax/bayesian-methods/knowledge/domain.json
@@ -1,0 +1,11 @@
+{
+  "id": "bayesian_methods",
+  "display_name": "Bayesian Methods",
+  "description": "Bayesian statistical methods — priors and posteriors, conjugate families, credible intervals, MCMC/HMC/NUTS/variational inference, hierarchical and multilevel models, posterior predictive checks, Bayes factors, and the modern Bayesian workflow. Engine pack focus: turning KB findings from other packs into informative priors for Bayesian regression.",
+  "level_of_analysis": "macro",
+  "parent_domain_id": null,
+  "temporal_scope": null,
+  "population": null,
+  "research_questions": [],
+  "status": "active"
+}

--- a/pax/bayesian-methods/knowledge/findings.json
+++ b/pax/bayesian-methods/knowledge/findings.json
@@ -4,7 +4,10 @@
     "source_id": "gelfand_smith_1990_sampling_marginal",
     "domain_id": "bayesian_methods",
     "finding_text": "Gibbs sampling and related sampling-based approaches provide a general, computationally feasible route to marginal and conditional posterior distributions in Bayesian hierarchical models where analytical integration is intractable. Enabled the wide adoption of MCMC for applied Bayesian inference in the 1990s.",
-    "construct_ids": "markov_chain_monte_carlo,posterior_distribution",
+    "construct_ids": [
+      "markov_chain_monte_carlo",
+      "posterior_distribution"
+    ],
     "direction": "positive",
     "effect_size": null,
     "method_used": "theoretical derivation; simulation studies on hierarchical Normal and binomial models",
@@ -25,8 +28,11 @@
     "id": 2,
     "source_id": "gelman_2006_variance_priors",
     "domain_id": "bayesian_methods",
-    "finding_text": "Inverse-Gamma(ε, ε) priors on variance parameters — a historically common 'non-informative' default in hierarchical Bayesian models — are in fact strongly informative with influence that does not vanish as ε → 0. Half-Cauchy and half-Normal priors on the standard deviation are recommended weakly-informative alternatives that avoid this pathology.",
-    "construct_ids": "weakly_informative_prior,hierarchical_model",
+    "finding_text": "Inverse-Gamma(\u03b5, \u03b5) priors on variance parameters \u2014 a historically common 'non-informative' default in hierarchical Bayesian models \u2014 are in fact strongly informative with influence that does not vanish as \u03b5 \u2192 0. Half-Cauchy and half-Normal priors on the standard deviation are recommended weakly-informative alternatives that avoid this pathology.",
+    "construct_ids": [
+      "weakly_informative_prior",
+      "hierarchical_model"
+    ],
     "direction": "positive",
     "effect_size": null,
     "method_used": "analytical analysis of prior influence; simulation comparison on 8-schools-style hierarchical model",
@@ -48,7 +54,11 @@
     "source_id": "hoffman_gelman_2014_nuts",
     "domain_id": "bayesian_methods",
     "finding_text": "The No-U-Turn Sampler matches or exceeds the efficiency of hand-tuned HMC across a range of target distributions while eliminating the need to specify trajectory length, and outperforms random-walk Metropolis by one to three orders of magnitude in effective sample size per gradient evaluation on correlated Gaussian and logistic regression targets.",
-    "construct_ids": "no_u_turn_sampler,hamiltonian_monte_carlo,effective_sample_size",
+    "construct_ids": [
+      "no_u_turn_sampler",
+      "hamiltonian_monte_carlo",
+      "effective_sample_size"
+    ],
     "direction": "positive",
     "effect_size": "1-3 orders of magnitude ESS/grad-eval improvement vs. random-walk Metropolis",
     "method_used": "benchmark on 250-dim correlated Gaussian, logistic regression, hierarchical Bayesian logistic regression",
@@ -70,7 +80,10 @@
     "source_id": "blei_2017_vi_review",
     "domain_id": "bayesian_methods",
     "finding_text": "Mean-field variational inference provides dramatically faster approximate posterior inference than MCMC on large-scale latent-variable models (e.g. LDA topic models with millions of documents), at the cost of underestimating posterior variance due to the KL(q||p) forward-KL objective that is mode-seeking rather than mean-matching.",
-    "construct_ids": "variational_inference,posterior_distribution",
+    "construct_ids": [
+      "variational_inference",
+      "posterior_distribution"
+    ],
     "direction": "mixed",
     "effect_size": null,
     "method_used": "review of applications; comparison to MCMC on LDA, Gaussian mixtures, Bayesian nonparametrics",
@@ -92,7 +105,10 @@
     "source_id": "gelman_hill_2006_multilevel",
     "domain_id": "bayesian_methods",
     "finding_text": "Partial pooling via hierarchical models produces group-level estimates with lower mean squared error than either complete pooling (ignoring group structure) or no pooling (fitting separate models per group), particularly for groups with small sample sizes. The shrinkage is automatic and adapts to the estimated between-group variance.",
-    "construct_ids": "hierarchical_model,bayesian_linear_regression",
+    "construct_ids": [
+      "hierarchical_model",
+      "bayesian_linear_regression"
+    ],
     "direction": "positive",
     "effect_size": null,
     "method_used": "textbook demonstration across Radon, 8-schools, roaches, and election forecasting case studies",
@@ -113,8 +129,11 @@
     "id": 6,
     "source_id": "gelman_meng_stern_1996_posterior_predictive",
     "domain_id": "bayesian_methods",
-    "finding_text": "Posterior predictive checks using realized discrepancy measures T(y, θ) — test quantities that may depend on both data and parameters — provide a principled Bayesian analogue to goodness-of-fit testing. Systematic divergence between T applied to observed vs. replicated data reveals specific modes of model misspecification that point estimates of fit cannot.",
-    "construct_ids": "posterior_predictive_check,posterior_distribution",
+    "finding_text": "Posterior predictive checks using realized discrepancy measures T(y, \u03b8) \u2014 test quantities that may depend on both data and parameters \u2014 provide a principled Bayesian analogue to goodness-of-fit testing. Systematic divergence between T applied to observed vs. replicated data reveals specific modes of model misspecification that point estimates of fit cannot.",
+    "construct_ids": [
+      "posterior_predictive_check",
+      "posterior_distribution"
+    ],
     "direction": "positive",
     "effect_size": null,
     "method_used": "theoretical framework with applications to hierarchical models and binomial/normal data",
@@ -136,7 +155,11 @@
     "source_id": "kass_raftery_1995_bayes_factors",
     "domain_id": "bayesian_methods",
     "finding_text": "Bayes factors are sensitive to the choice of prior on model parameters in a way that p-values are not; improper priors under the models being compared render the Bayes factor undefined. Proper, weakly-informative priors chosen with the comparison in mind are required for interpretable model comparison.",
-    "construct_ids": "bayes_factor,weakly_informative_prior,informative_prior",
+    "construct_ids": [
+      "bayes_factor",
+      "weakly_informative_prior",
+      "informative_prior"
+    ],
     "direction": "negative",
     "effect_size": null,
     "method_used": "review of theoretical and applied literature on Bayesian model comparison",
@@ -157,8 +180,11 @@
     "id": 8,
     "source_id": "simpson_2017_pc_priors",
     "domain_id": "bayesian_methods",
-    "finding_text": "Penalised Complexity (PC) priors constructed by penalizing KL divergence from a simpler base model (e.g. zero variance, independence) produce interpretable, weakly-informative defaults for random-effect variances, autoregressive correlation parameters, and overdispersion terms — with a single user-chosen scale that has clear probabilistic meaning.",
-    "construct_ids": "weakly_informative_prior,hierarchical_model",
+    "finding_text": "Penalised Complexity (PC) priors constructed by penalizing KL divergence from a simpler base model (e.g. zero variance, independence) produce interpretable, weakly-informative defaults for random-effect variances, autoregressive correlation parameters, and overdispersion terms \u2014 with a single user-chosen scale that has clear probabilistic meaning.",
+    "construct_ids": [
+      "weakly_informative_prior",
+      "hierarchical_model"
+    ],
     "direction": "positive",
     "effect_size": null,
     "method_used": "derivation from KL-divergence base-model penalization; applications to BYM spatial models, AR(1) parameters",
@@ -180,7 +206,11 @@
     "source_id": "carpenter_2017_stan",
     "domain_id": "bayesian_methods",
     "finding_text": "Stan's implementation of NUTS with dynamic trajectory doubling, dual-averaging step-size adaptation, and dense-mass-matrix adaptation produces reliable posterior samples for a wide class of continuous-parameter Bayesian models without user tuning. Combined with automatic differentiation and a C++ backend, it enables Bayesian inference at scales previously requiring bespoke Gibbs samplers.",
-    "construct_ids": "no_u_turn_sampler,hamiltonian_monte_carlo,bayesian_linear_regression",
+    "construct_ids": [
+      "no_u_turn_sampler",
+      "hamiltonian_monte_carlo",
+      "bayesian_linear_regression"
+    ],
     "direction": "positive",
     "effect_size": null,
     "method_used": "description of Stan implementation; benchmarks on hierarchical GLMs, IRT, Gaussian processes",
@@ -202,7 +232,10 @@
     "source_id": "beaumont_2010_abc",
     "domain_id": "bayesian_methods",
     "finding_text": "Approximate Bayesian Computation enables posterior inference for models with intractable likelihoods (e.g. coalescent simulators, agent-based models) by replacing likelihood evaluation with simulation and distance-based acceptance of parameters. ABC-SMC and regression-adjustment variants substantially improve efficiency over rejection ABC for moderate-dimensional parameter spaces.",
-    "construct_ids": "posterior_distribution,markov_chain_monte_carlo",
+    "construct_ids": [
+      "posterior_distribution",
+      "markov_chain_monte_carlo"
+    ],
     "direction": "positive",
     "effect_size": null,
     "method_used": "review of rejection ABC, ABC-MCMC, ABC-SMC with applications in population genetics and epidemiology",
@@ -223,8 +256,13 @@
     "id": 11,
     "source_id": "vandeschoot_2021_bayesian_primer",
     "domain_id": "bayesian_methods",
-    "finding_text": "The modern applied Bayesian workflow centers on iterative model building: start with weakly-informative priors and a simple model, use HMC/NUTS for posterior computation, apply posterior predictive checks to detect misspecification, refine priors and model structure, and validate via cross-validation (e.g. PSIS-LOO). Prior sensitivity analysis — refitting with varied priors — is recommended for any published Bayesian analysis.",
-    "construct_ids": "weakly_informative_prior,posterior_predictive_check,no_u_turn_sampler,hierarchical_model",
+    "finding_text": "The modern applied Bayesian workflow centers on iterative model building: start with weakly-informative priors and a simple model, use HMC/NUTS for posterior computation, apply posterior predictive checks to detect misspecification, refine priors and model structure, and validate via cross-validation (e.g. PSIS-LOO). Prior sensitivity analysis \u2014 refitting with varied priors \u2014 is recommended for any published Bayesian analysis.",
+    "construct_ids": [
+      "weakly_informative_prior",
+      "posterior_predictive_check",
+      "no_u_turn_sampler",
+      "hierarchical_model"
+    ],
     "direction": "positive",
     "effect_size": null,
     "method_used": "expert consensus review across Bayesian methodology community",
@@ -246,7 +284,10 @@
     "source_id": "kruschke_2015_dbda",
     "domain_id": "bayesian_methods",
     "finding_text": "Bayesian credible intervals admit the direct probabilistic interpretation that practitioners often incorrectly ascribe to frequentist confidence intervals. This interpretive clarity, combined with modeling flexibility for hierarchical and non-standard likelihoods, is a primary reason behavioral and social sciences have increasingly adopted Bayesian methods.",
-    "construct_ids": "credible_interval,posterior_distribution",
+    "construct_ids": [
+      "credible_interval",
+      "posterior_distribution"
+    ],
     "direction": "positive",
     "effect_size": null,
     "method_used": "pedagogical exposition with worked examples across t-tests, ANOVA, regression, and hierarchical models",


### PR DESCRIPTION
First pack from #83 cleared. Two data corrections, no content invented:

1. **Add `knowledge/domain.json`** — the manifest declared `domain_id: bayesian_methods` but no domain entity was ever persisted. New file carries the canonical id + description derived from `pax.yaml.description`.
2. **Normalize `construct_ids` in 12 findings** — comma-separated string → JSON array per PAX_FIELDS spec.

Validator passes:
```
$ python3 scripts/validate_pax.py pax/bayesian-methods
✓ bayesian-methods: all checks passed
```

10 broken packs remain in #83. Each needs similar treatment or a clean re-export from praxis once export-side fixes land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)